### PR TITLE
Add metris_converter

### DIFF
--- a/src/metrics_config.py
+++ b/src/metrics_config.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import collectd
 from metrics_util import MetricsUtil
 

--- a/src/metrics_converter.py
+++ b/src/metrics_converter.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import collectd
 from metrics_util import MetricsUtil
 

--- a/src/metrics_util.py
+++ b/src/metrics_util.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import collectd
 
 class MetricsUtil:

--- a/test/test_metrics_config.py
+++ b/test/test_metrics_config.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 cwd = os.getcwd()
 import sys
@@ -223,6 +225,19 @@ def test_types_db_no_exist_exception():
         met_config.parse_config(config)
 
     assert 'No such file or directory' in str(e.value)
+
+
+def test_non_ascii_strings():
+    met_config = MetricsConfig()
+
+    configs = {
+        'source_name': '数据源',
+    }
+
+    Helper.parse_configs(met_config, configs)
+
+    assert met_config.conf[ConfigOptions.source_name] == '数据源'
+
 
 
 def tags_node(key, values):

--- a/test/test_metrics_converter.py
+++ b/test/test_metrics_converter.py
@@ -34,7 +34,8 @@ def test_gen_key_not_string_exception():
     with pytest.raises(Exception) as e:
         gen_tag(('tag_key', ), 'tag_value')
 
-    assert "Key ('tag_key',) for Value tag_value must be string type. Type is <type 'tuple'>" in str(e.value)
+    assert "Key ('tag_key',) for Value tag_value must be string type. Type is <type 'tuple'>" in \
+           str(e.value)
 
 
 def test_gen_value_not_string_exception():
@@ -83,7 +84,8 @@ def test_convert_to_metrics_multiple():
 
 
 def test_convert_to_metrics_no_meta():
-    d = Values(type='test_type_2', meta={}, values=[1.23, 4.56], ds_names=['test_ds_name1', 'test_ds_name2'],
+    d = Values(type='test_type_2', meta={}, values=[1.23, 4.56],
+               ds_names=['test_ds_name1', 'test_ds_name2'],
                ds_types=['test_ds_type1', 'test_ds_type2'])
     helper = Helper()
     metrics = convert_to_metrics(d, helper.types)
@@ -110,5 +112,3 @@ def test_convert_to_metrics_type_nonexist_exception():
 
     assert 'Do not know how to handle type test_type_3. ' \
            'Do you have all your types.db files configured?' in str(e.value)
-
-


### PR DESCRIPTION
---------------------------------------------------------------------------------------------------------------------------------------------------
It can be helpful to read the project readme to get the context of the collectd-plugin here https://github.com/SumoLogic/sumologic-collectd-plugin
---------------------------------------------------------------------------------------------------------------------------------------------------

This PR includes source code and tests for converting CollectD data model to Carbon 2.0 metric. 

CollectD data model is  `(host, plugin, plugin_instance, type, type_instance, time, interval, metadata, values)`. The meaning of each `value` in `values` is defined in `types.db` file. Each value has its own `ds_name` (data source name), `ds_type`(data source type)
Carbon 2.0 metric is of format `(dimensions  metadata value timestamp)`, if metadata is missing, then `(dimensions  value timestamp)` https://github.com/SumoLogic/sumologic-collectd-plugin#data-model