### PR TITLE
Register shutdown cleanup

### DIFF
--- a/src/metrics_batcher.py
+++ b/src/metrics_batcher.py
@@ -19,7 +19,7 @@ class MetricsBatcher(Timer):
         Init MetricsBatcher with max_batch_size, max_batch_interval, and met_buffer
         """
 
-        Timer.__init__(self, max_batch_interval, self._flush)
+        Timer.__init__(self, max_batch_interval, self.flush)
 
         # initiate max_batch_size and max_batch_interval
         self.max_batch_size = max_batch_size
@@ -45,9 +45,9 @@ class MetricsBatcher(Timer):
 
         self.queue.put(item)
         if self._batch_full():
-            self._flush()
+            self.flush()
 
-    def _flush(self):
+    def flush(self):
 
         if self.queue.empty():
             collectd.debug('queue is empty')

--- a/src/metrics_buffer.py
+++ b/src/metrics_buffer.py
@@ -66,3 +66,6 @@ class MetricsBuffer:
             collectd.warning('Sending metrics batch %s failed. '
                              'Put it back to processing queue' % batch)
             self.processing_queue.put(batch)
+
+    def empty(self):
+        return self.processing_queue.empty() and self.pending_queue.empty()

--- a/src/metrics_config.py
+++ b/src/metrics_config.py
@@ -35,6 +35,7 @@ class ConfigOptions:
     content_encoding = 'ContentEncoding'
     # Static option, not configurable yet. Default is application/vnd.sumologic.carbon2
     content_type = 'ContentType'
+    shutdown_max_wait = "ShutdownMaxWait"  # seconds
 
 
 class MetricsConfig:
@@ -66,8 +67,9 @@ class MetricsConfig:
             ConfigOptions.retry_jitter_min: 0,
             ConfigOptions.retry_jitter_max: 10,
             ConfigOptions.max_requests_to_buffer: 1000,
+            ConfigOptions.content_encoding: 'deflate',
             ConfigOptions.content_type: 'application/vnd.sumologic.carbon2',
-            ConfigOptions.content_encoding: 'deflate'
+            ConfigOptions.shutdown_max_wait: 5
         }
 
     def parse_config(self, config):

--- a/src/metrics_writer.py
+++ b/src/metrics_writer.py
@@ -62,7 +62,6 @@ def shutdown_callback():
     # Increase frequency for scheduling http requests
     met_sender.interval = flush_interval
     while time.time() < stop and (not met_buffer.empty()):
-        met_batcher.flush()
         time.sleep(flush_interval)
 
 

--- a/src/metrics_writer.py
+++ b/src/metrics_writer.py
@@ -57,6 +57,7 @@ def shutdown_callback():
     """
     now = time.time()
     stop = now + met_config.conf[ConfigOptions.shutdown_max_wait]
+    met_batcher.cancel_timer()
     met_batcher.flush()
     flush_interval = 0.1  # 100 ms
     # Increase frequency for scheduling http requests

--- a/src/metrics_writer.py
+++ b/src/metrics_writer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import collectd
+import time
 from metrics_config import MetricsConfig, ConfigOptions
 from metrics_buffer import MetricsBuffer
 from metrics_converter import convert_to_metrics
@@ -50,6 +51,22 @@ def write_callback(raw_data, data=None):
         met_batcher.push_item(metric)
 
 
+def shutdown_callback():
+    """
+    Shutdown callback. Flushes in memory metrics batches. Default, times out at 5 seconds.
+    """
+    now = time.time()
+    stop = now + met_config.conf[ConfigOptions.shutdown_max_wait]
+    met_batcher.flush()
+    flush_interval = 0.1  # 100 ms
+    # Increase frequency for scheduling http requests
+    met_sender.interval = flush_interval
+    while time.time() < stop and (not met_buffer.empty()):
+        met_batcher.flush()
+        time.sleep(flush_interval)
+
+
 collectd.register_config(config_callback)
 collectd.register_init(init_callback)
 collectd.register_write(write_callback)
+collectd.register_shutdown(shutdown_callback)

--- a/test/collectd/__init__.py
+++ b/test/collectd/__init__.py
@@ -1,3 +1,3 @@
-from . register import (register_config, register_init, register_read, register_write)
+from . register import (register_config, register_init, register_write, register_shutdown)
 
 from . logger import (debug, info, warning, error)

--- a/test/collectd/register.py
+++ b/test/collectd/register.py
@@ -6,9 +6,9 @@ def register_init(func):
     pass
 
 
-def register_read(func):
+def register_write(func):
     pass
 
 
-def register_write(func):
+def register_shutdown(func):
     pass

--- a/test/test_metrics_sender.py
+++ b/test/test_metrics_sender.py
@@ -146,7 +146,7 @@ def test_post_client_recoverable_http_error():
 
 
 def test_post_server_recoverable_http_error():
-    error_codes = [500, 502, 503, 504, 506, 507, 508, 510, 511]
+    error_codes = [500, 501, 502]
 
     for error_code in error_codes:
         reset_test_env()
@@ -160,15 +160,6 @@ def test_post_server_recoverable_http_error():
             assert_utf8_equal(met_config.conf, requests.mock_server.data[i], 'batch_%s' % i)
 
 
-def test_post_unrecoverable_http_error():
-    request_exception = requests.exceptions.RequestException()
-    exception_cases = [requests.exceptions.HTTPError(request_exception)]
-
-    for exception_case in exception_cases:
-        reset_test_env()
-        helper_test_post_unrecoverable_exception(exception_case, "unknown_status_code")
-
-
 def test_post_recoverable_requests_exception():
     request_exception = requests.exceptions.RequestException()
     exception_cases = [requests.exceptions.ConnectionError(request_exception),
@@ -177,7 +168,12 @@ def test_post_recoverable_requests_exception():
                        requests.exceptions.StreamConsumedError(request_exception),
                        requests.exceptions.RetryError(request_exception),
                        requests.exceptions.ChunkedEncodingError(request_exception),
-                       requests.exceptions.ContentDecodingError(request_exception)]
+                       requests.exceptions.ContentDecodingError(request_exception),
+                       requests.exceptions.URLRequired(request_exception),
+                       requests.exceptions.MissingSchema(request_exception),
+                       requests.exceptions.InvalidSchema(request_exception),
+                       requests.exceptions.InvalidURL(request_exception),
+                       Exception('unknown_exception')]
 
     for exception_case in exception_cases:
         reset_test_env()
@@ -187,19 +183,6 @@ def test_post_recoverable_requests_exception():
                                                "unknown_status_code", 5)
         for i in range(10):
             assert_utf8_equal(met_config.conf, requests.mock_server.data[i], 'batch_%s' % i)
-
-
-def test_post_unrecoverable_requests_exception():
-    request_exception = requests.exceptions.RequestException()
-    exception_cases = [requests.exceptions.URLRequired(request_exception),
-                       requests.exceptions.MissingSchema(request_exception),
-                       requests.exceptions.InvalidSchema(request_exception),
-                       requests.exceptions.InvalidURL(request_exception),
-                       Exception('unknown_exception')]
-
-    for exception_case in exception_cases:
-        reset_test_env()
-        helper_test_post_unrecoverable_exception(exception_case, "unknown_status_code")
 
 
 def test_post_fail_after_retries_with_buffer_full():

--- a/test/test_metrics_writer.py
+++ b/test/test_metrics_writer.py
@@ -3,6 +3,7 @@ cwd = os.getcwd()
 import sys
 sys.path.append(cwd + '/src')
 
+import time
 import metrics_writer
 from metrics_config import ConfigOptions
 from collectd.collectd_config import CollectdConfig
@@ -31,3 +32,19 @@ def test_write_callback():
     metrics_writer.write_callback(d)
     assert metrics_writer.met_batcher.queue.qsize() == 1
     assert [metrics_writer.met_batcher.queue.get()] == d.metrics_str()
+
+
+def test_shutdown_call_back():
+    config = CollectdConfig([Helper.url_node(), Helper.types_db_node()])
+    metrics_writer.config_callback(config)
+    metrics_writer.init_callback()
+
+    for i in range(10):
+        metrics_writer.met_buffer.put_pending_batch(['batch_%s' % i])
+
+    metrics_writer.shutdown_callback()
+
+    time.sleep(2)
+
+    assert metrics_writer.met_buffer.empty() == True
+


### PR DESCRIPTION
This PR added cleanups with flushing in-memory buffers when the shutdown callback is triggered by collectd. 

Accidentally push the commit  `Make all exceptions recoverable` https://github.com/SumoLogic/sumologic-collectd-plugin/pull/14/commits/93b36ac7a8683f0804fa7c6e33b232cb48cc5d36 into this PR. I guess I will just leave it here as we discussed it together. 

Travis is complaining about no baseline codecov report to compare to. Please ignore