### PR TITLE
Update header separator for sumo dimensions and metadata

### DIFF
--- a/src/metrics_converter.py
+++ b/src/metrics_converter.py
@@ -40,11 +40,11 @@ def _remove_empty_tags(tags):
     return [tag for tag in tags if tag]
 
 
-def tags_to_str(tags):
+def tags_to_str(tags, sep=' '):
         """
         Convert list of tags to a single string
         """
-        return ' '.join(_remove_empty_tags(tags))
+        return sep.join(_remove_empty_tags(tags))
 
 
 # Generate meta_tags from data

--- a/src/metrics_sender.py
+++ b/src/metrics_sender.py
@@ -140,11 +140,11 @@ class MetricsSender(Timer):
 
         # Add custom dimension_tags specified in conf
         if ConfigOptions.dimension_tags in config_keys:
-            headers[HeaderKeys.x_sumo_dimensions] = tags_to_str(self._gen_config_dimension_tags())
+            headers[HeaderKeys.x_sumo_dimensions] = tags_to_str(self._gen_config_dimension_tags(), sep=',')
 
         # Add custom meta_tags specified in conf
         if ConfigOptions.meta_tags in config_keys:
-            headers[HeaderKeys.x_sumo_metadata] = tags_to_str(self._gen_config_meta_tags())
+            headers[HeaderKeys.x_sumo_metadata] = tags_to_str(self._gen_config_meta_tags(), sep=',')
 
         return headers
 

--- a/test/test_metrics_sender.py
+++ b/test/test_metrics_sender.py
@@ -121,8 +121,8 @@ def test_post_normal_addition_dimensions_metadata():
     assert requests.mock_server.headers == {
         HeaderKeys.content_type: met_config.conf[ConfigOptions.content_type],
         HeaderKeys.content_encoding: met_config.conf[ConfigOptions.content_encoding],
-        HeaderKeys.x_sumo_dimensions: 'dim_key1=dim_val1 dim_key2=dim_val2',
-        HeaderKeys.x_sumo_metadata: 'meta_key1=meta_val1 meta_key2=meta_val2',
+        HeaderKeys.x_sumo_dimensions: 'dim_key1=dim_val1,dim_key2=dim_val2',
+        HeaderKeys.x_sumo_metadata: 'meta_key1=meta_val1,meta_key2=meta_val2',
     }
 
     for i in range(10):


### PR DESCRIPTION
Sumo dimensions and metadata needs to be separated with `,` instead of space. This PR fixes it. 