### PR TITLE
don't send nan into sumo

### DIFF
--- a/sumologic_collectd_metrics/metrics_converter.py
+++ b/sumologic_collectd_metrics/metrics_converter.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from metrics_util import validate_field, validate_type
+import math
 
 
 class IntrinsicKeys(object):
@@ -88,6 +89,8 @@ def convert_to_metrics(data, types):
     metrics = []
 
     for (value, data_type) in zip(data.values, types[data.type]):
+        if (math.isnan(value)):
+            continue;
         ds_name = data_type[0]
         ds_type = data_type[1]
 


### PR DESCRIPTION
there are some values in collectd that are "nan". 

For example in the statsd plugin, it will send in nan.

If there are 100 stats going into sumo and 1 is nan, the whole request into sumo gets rejected with a 400.

The nan's need to be filtered out.
