### PR TITLE
increase version to 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
             return f.read()
 
 setup(name='sumologic_collectd_metrics',
-      version='1.0.1',
+      version='2.0.0',
       description='A collectd output plugin to send Carbon 2.0-formatted metrics to Sumo Logic.',
       long_description=readme(),
       url='https://github.com/SumoLogic/sumologic-collectd-plugin',


### PR DESCRIPTION
- force to convert tag attributes and names to string
- replace `=`  with `:` for tag names and values

Signed-off-by: Dominik Rosiek <drosiek@sumologic.com>