### PR TITLE
test(vagrant): use IP address from allowed range

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,9 @@ Vagrant.configure('2') do |config|
   config.vm.box = 'ubuntu/focal64'
   config.vm.box_check_update = false
   config.vm.host_name = 'sumologic-collectd-plugin'
-  config.vm.network :private_network, ip: "192.168.78.43"
+  # Vbox 6.1.28+ restricts host-only adapters to 192.168.56.0/21
+  # See: https://www.virtualbox.org/manual/ch06.html#network_hostonly
+  config.vm.network :private_network, ip: "192.168.56.43"
 
   config.vm.provider 'virtualbox' do |vb|
     vb.gui = false


### PR DESCRIPTION
Today during `vagrant up` I got the following error:

```
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Clearing any previously set forwarded ports...
==> default: Clearing any previously set network interfaces...
The IP address configured for the host-only network is not within the
allowed ranges. Please update the address used to be within the allowed
ranges and run the command again.

  Address: 192.168.78.43
  Ranges: 192.168.56.0/21

Valid ranges can be modified in the /etc/vbox/networks.conf file. For
more information including valid format see:

  https://www.virtualbox.org/manual/ch06.html#network_hostonly
```
This is using Vagrant 2.2.19, VirtualBox 6.1.28.

This changes the IP address of the Vagrant machine to 192.168.56.*.