### PR TITLE
fix: fix race condition in timer

### DIFF
--- a/sumologic_collectd_metrics/timer.py
+++ b/sumologic_collectd_metrics/timer.py
@@ -27,23 +27,20 @@ class Timer:
         Start a thread to periodically run task func
         """
 
-        if hasattr(self, 'collectd'):
-            self.collectd.debug('Timer has been run: %s.' %
-                                self.__class__.__name__)
-        if self.run_count >= self.run_count_reset:
+        with self.start_timer_lock:
             if hasattr(self, 'collectd'):
-                self.collectd.info('Timer %s has run %s times.' % (
-                    self.__class__.__name__, self.run_count))
-            self.run_count = 0
-        self.run_count += 1
+                self.collectd.debug('Timer has been run: %s.' %
+                                    self.__class__.__name__)
+            if self.run_count >= self.run_count_reset:
+                if hasattr(self, 'collectd'):
+                    self.collectd.info('Timer %s has run %s times.' % (
+                        self.__class__.__name__, self.run_count))
+                self.run_count = 0
+            self.run_count += 1
 
-        self.timer = threading.Timer(self.interval, self.start_timer)
-        self.timer.daemon = True
-        # Lock to resolve racing condition for start_timer and reset_timer
-        if self.start_timer_lock.acquire(False):  # pylint: disable=R1732
-            if not self.timer.is_alive():
-                self.timer.start()
-            self.start_timer_lock.release()
+            self.timer = threading.Timer(self.interval, self.start_timer)
+            self.timer.daemon = True
+            self.timer.start()
 
         self.task()
 


### PR DESCRIPTION
When scheduling a new task using the Timer class, the lock protecting the timer object is taken optimistically, which can cause a race condition where the new timer thread does not start its successor.