### PR TITLE
feat: add timer logs

### DIFF
--- a/sumologic_collectd_metrics/metrics_batcher.py
+++ b/sumologic_collectd_metrics/metrics_batcher.py
@@ -18,10 +18,8 @@ class MetricsBatcher(Timer):
         Init MetricsBatcher with max_batch_size, max_batch_interval, and met_buffer
         """
 
-        Timer.__init__(self, max_batch_interval, self.flush)
-
         self.collectd = collectd
-
+        Timer.__init__(self, max_batch_interval, self.flush)
         # initiate max_batch_size and max_batch_interval
         self.max_batch_size = max_batch_size
         self.max_batch_interval = max_batch_interval

--- a/sumologic_collectd_metrics/metrics_sender.py
+++ b/sumologic_collectd_metrics/metrics_sender.py
@@ -39,9 +39,8 @@ class MetricsSender(Timer):
         Init MetricsSender with conf and met_buf
         """
 
-        Timer.__init__(self, conf[ConfigOptions.http_post_interval], self._request_scheduler)
-
         self.collectd = collectd
+        Timer.__init__(self, conf[ConfigOptions.http_post_interval], self._request_scheduler)
         self.conf = conf
         self.buffer = met_buf
         self.http_headers = self._build_header()

--- a/sumologic_collectd_metrics/timer.py
+++ b/sumologic_collectd_metrics/timer.py
@@ -13,6 +13,11 @@ class Timer:
         self.task = task
         self.timer = None
         self.start_timer_lock = threading.Lock()
+        self.run_count = 0
+        self.run_count_reset = 60 / interval
+        if hasattr(self, 'collectd'):
+            self.collectd.info('Timer %s will report once a minute (every %s runs).' % (
+                self.__class__.__name__, self.run_count_reset))
 
     def __del__(self):
         self.cancel_timer()
@@ -21,6 +26,16 @@ class Timer:
         """
         Start a thread to periodically run task func
         """
+
+        if hasattr(self, 'collectd'):
+            self.collectd.debug('Timer has been run: %s.' %
+                                self.__class__.__name__)
+        if self.run_count >= self.run_count_reset:
+            if hasattr(self, 'collectd'):
+                self.collectd.info('Timer %s has run %s times.' % (
+                    self.__class__.__name__, self.run_count))
+            self.run_count = 0
+        self.run_count += 1
 
         self.timer = threading.Timer(self.interval, self.start_timer)
         self.timer.daemon = True
@@ -33,9 +48,15 @@ class Timer:
         self.task()
 
     def cancel_timer(self):
+        if hasattr(self, 'collectd'):
+            self.collectd.debug('Timer has been canceled: %s.' %
+                                self.__class__.__name__)
         if self.timer is not None:
             self.timer.cancel()
 
     def reset_timer(self):
+        if hasattr(self, 'collectd'):
+            self.collectd.debug('Timer has been reset: %s' %
+                                self.__class__.__name__)
         self.cancel_timer()
         self.start_timer()


### PR DESCRIPTION
This adds logs around timers.
These can be useful to investigate issues when data is not sent to Sumo.