### PR TITLE
ci: update version matrix

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Version 3.5 has been out of support for a year now https://devguide.python.org/#status-of-python-branches, https://devguide.python.org/devcycle/#end-of-life-branches, and GitHub will be removing Python 3.5 from its runners in January 2022 https://github.com/actions/virtual-environments/issues/4744.

Also added the missing current versions 3.9, 3.10.