### PR TITLE
chore: lint and format using black and isort

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -19,11 +19,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: make install
+      run: make install-test
     - name: Test with pytest
       run: make pytest
 
-  pylint:
+  lint:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -31,5 +31,5 @@ jobs:
       uses: actions/setup-python@v2
     - name: Install dependencies
       run: make install
-    - name: Lint with pylint
-      run: make pylint
+    - name: Lint
+      run: make lint

--- a/.pylintrc
+++ b/.pylintrc
@@ -16,4 +16,5 @@ disable=
     too-many-statements,
     useless-object-inheritance,
     duplicate-code,
+    c-extension-no-member, # https://github.com/PyCQA/pylint/issues/3499
     consider-using-f-string,  # not supported in python2.7

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,24 @@
 test: install pytest
 
-install:
-	python -m pip install -r requirements.txt
+install: install-lint install-test
+
+install-test:
+	python -m pip install -r requirements-test.txt
+
+install-lint:
+	python -m pip install -r requirements-lint.txt
 
 pytest:
 	python -m pytest -v test/ --cov=sumologic_collectd_metrics/
 
-pylint:
+lint:
 	python -m pylint **/*.py
+	black --check .
+	isort --check .
+
+format:
+	black .
+	isort .
 
 # https://packaging.python.org/tutorials/packaging-projects/
 .PHONY: build

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,5 @@
+# This is a separate file because black doesn't run on Python 2, eveb though it
+# supports formatting Python 2 syntax.
+pylint~=2.12.2
+black==21.12b0
+isort~=5.10.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,4 +5,3 @@ retry
 # test dependencies
 urllib3
 pytest-cov
-pylint

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[isort]
+profile = black

--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,21 @@ from setuptools import setup
 
 
 def readme():
-      with open('README.rst') as f:
-            return f.read()
+    with open("README.rst") as f:
+        return f.read()
 
-setup(name='sumologic_collectd_metrics',
-      version='4.0.1',
-      description='A collectd output plugin to send Carbon 2.0-formatted metrics to Sumo Logic.',
-      long_description=readme(),
-      url='https://github.com/SumoLogic/sumologic-collectd-plugin',
-      author='Sumo Logic',
-      author_email='support@sumologic.com',
-      license='Apache Software License, Version 2.0',
-      packages=['sumologic_collectd_metrics'],
-      install_requires=[
-            'requests',
-            'retry'
-      ],
-      tests_require=[
-            "pytest",
-            "urllib3",
-            "pytest-cov"
-      ],
-      zip_safe=False)
+
+setup(
+    name="sumologic_collectd_metrics",
+    version="4.0.1",
+    description="A collectd output plugin to send Carbon 2.0-formatted metrics to Sumo Logic.",
+    long_description=readme(),
+    url="https://github.com/SumoLogic/sumologic-collectd-plugin",
+    author="Sumo Logic",
+    author_email="support@sumologic.com",
+    license="Apache Software License, Version 2.0",
+    packages=["sumologic_collectd_metrics"],
+    install_requires=["requests", "retry"],
+    tests_require=["pytest", "urllib3", "pytest-cov"],
+    zip_safe=False,
+)

--- a/sumologic_collectd_metrics/__init__.py
+++ b/sumologic_collectd_metrics/__init__.py
@@ -1,15 +1,17 @@
 try:  # pragma: no cover
     import collectd
+
     COLLECTD_PRESENT = True
 except (ImportError, AttributeError):  # pragma: no cover
     COLLECTD_PRESENT = False
 
-from . metrics_writer import MetricsWriter  # pragma: no cover
+from .metrics_writer import MetricsWriter  # pragma: no cover
 
 
 def config_callback(conf):  # pragma: no cover
     met_writer.parse_config(conf)
     met_writer.register()
+
 
 if COLLECTD_PRESENT:  # pragma: no cover
     met_writer = MetricsWriter(collectd)

--- a/sumologic_collectd_metrics/metrics_batcher.py
+++ b/sumologic_collectd_metrics/metrics_batcher.py
@@ -4,7 +4,9 @@ try:
     import Queue as queue
 except ImportError:
     import queue
+
 import threading
+
 from .timer import Timer
 
 
@@ -34,8 +36,10 @@ class MetricsBatcher(Timer):
         # start timer
         self.start_timer()
 
-        collectd.info('Initialized MetricsBatcher with max_batch_size %s, max_batch_interval %s' %
-                      (max_batch_size, max_batch_interval))
+        collectd.info(
+            "Initialized MetricsBatcher with max_batch_size %s, max_batch_interval %s"
+            % (max_batch_size, max_batch_interval)
+        )
 
     def push_item(self, item):
         """
@@ -49,11 +53,11 @@ class MetricsBatcher(Timer):
     def flush(self):
 
         if self.queue.empty():
-            self.collectd.debug('queue is empty')
+            self.collectd.debug("queue is empty")
             return
         if self.flushing_lock.acquire(False):  # pylint: disable=R1732
             batch = self._pop_batch()
-            self.collectd.debug('flushing metrics with batch size %d' % len(batch))
+            self.collectd.debug("flushing metrics with batch size %d" % len(batch))
             self.metrics_buffer.put_pending_batch(batch)
             self.reset_timer()
             self.flushing_lock.release()

--- a/sumologic_collectd_metrics/metrics_buffer.py
+++ b/sumologic_collectd_metrics/metrics_buffer.py
@@ -24,8 +24,10 @@ class MetricsBuffer(object):
         self.processing_queue = queue.Queue(self._processing_queue_size)
         self.pending_queue = queue.Queue(max_requests_to_buffer)
 
-        collectd.info('Initialized MetricsBuffer with max_requests_to_buffer %s' %
-                      max_requests_to_buffer)
+        collectd.info(
+            "Initialized MetricsBuffer with max_requests_to_buffer %s"
+            % max_requests_to_buffer
+        )
 
     def get_batch(self):
         """
@@ -49,8 +51,9 @@ class MetricsBuffer(object):
 
         if self.pending_queue.full():
             batch_to_drop = self.pending_queue.get()
-            self.collectd.warning('In memory buffer is full, dropping metrics batch %s'
-                                  % batch_to_drop)
+            self.collectd.warning(
+                "In memory buffer is full, dropping metrics batch %s" % batch_to_drop
+            )
 
         self.pending_queue.put(batch)
 
@@ -60,11 +63,15 @@ class MetricsBuffer(object):
         """
 
         if self.pending_queue.full():
-            self.collectd.warning('Sending metrics batch %s failed. '
-                                  'In memory buffer is full, dropping metrics batch' % batch)
+            self.collectd.warning(
+                "Sending metrics batch %s failed. "
+                "In memory buffer is full, dropping metrics batch" % batch
+            )
         else:
-            self.collectd.warning('Sending metrics batch %s failed. '
-                                  'Put it back to processing queue' % batch)
+            self.collectd.warning(
+                "Sending metrics batch %s failed. "
+                "Put it back to processing queue" % batch
+            )
             self.processing_queue.put(batch)
 
     def empty(self):

--- a/sumologic_collectd_metrics/metrics_config.py
+++ b/sumologic_collectd_metrics/metrics_config.py
@@ -1,49 +1,55 @@
 # -*- coding: utf-8 -*-
 
-from .metrics_util import (validate_boolean_type, validate_non_empty,
-                           validate_non_negative, validate_positive,
-                           validate_string_type)
+from .metrics_util import (
+    validate_boolean_type,
+    validate_non_empty,
+    validate_non_negative,
+    validate_positive,
+    validate_string_type,
+)
 
 
 class ConfigOptions(object):
     """
     Config options
     """
-    url = 'URL'
+
+    url = "URL"
     # Http header options
-    dimension_tags = 'Dimensions'
-    meta_tags = 'Metadata'
-    source_name = 'SourceName'
-    host_name = 'SourceHost'
-    source_category = 'SourceCategory'
+    dimension_tags = "Dimensions"
+    meta_tags = "Metadata"
+    source_name = "SourceName"
+    host_name = "SourceHost"
+    source_category = "SourceCategory"
     # Metrics Batching options
-    max_batch_size = 'MaxBatchSize'
-    max_batch_interval = 'MaxBatchInterval'
+    max_batch_size = "MaxBatchSize"
+    max_batch_interval = "MaxBatchInterval"
     # Http post request frequency option
-    http_post_interval = 'HttpPostInterval'
+    http_post_interval = "HttpPostInterval"
     # Http retry options
-    retry_initial_delay = 'RetryInitialDelay'
-    retry_max_attempts = 'RetryMaxAttempts'
-    retry_max_delay = 'RetryMaxDelay'
-    retry_backoff = 'RetryBackOff'
-    retry_jitter_min = 'RetryJitterMin'
-    retry_jitter_max = 'RetryJitterMax'
+    retry_initial_delay = "RetryInitialDelay"
+    retry_max_attempts = "RetryMaxAttempts"
+    retry_max_delay = "RetryMaxDelay"
+    retry_backoff = "RetryBackOff"
+    retry_jitter_min = "RetryJitterMin"
+    retry_jitter_max = "RetryJitterMax"
     # Memory option
-    max_requests_to_buffer = 'MaxRequestsToBuffer'
+    max_requests_to_buffer = "MaxRequestsToBuffer"
     # Content encoding option
-    content_encoding = 'ContentEncoding'
+    content_encoding = "ContentEncoding"
     # Static option, not configurable yet. Default is application/vnd.sumologic.carbon2
-    content_type = 'ContentType'
+    content_type = "ContentType"
     shutdown_max_wait = "ShutdownMaxWait"  # seconds
-    add_metric_dimension = 'AddMetricDimension'
-    metric_dimension_separator = 'MetricDimensionSeparator'
+    add_metric_dimension = "AddMetricDimension"
+    metric_dimension_separator = "MetricDimensionSeparator"
+
 
 class MetricsConfig:
     """
     Configuration for sumologic collectd plugin
     """
 
-    _content_encoding_set = frozenset(['deflate', 'gzip', 'none'])
+    _content_encoding_set = frozenset(["deflate", "gzip", "none"])
 
     def __init__(self, collectd):
         """
@@ -52,7 +58,7 @@ class MetricsConfig:
         self.collectd = collectd
         self.conf = self.default_config()
 
-        collectd.info('Initialized MetricsConfig with default config %s' % self.conf)
+        collectd.info("Initialized MetricsConfig with default config %s" % self.conf)
 
     @staticmethod
     def default_config():
@@ -67,11 +73,11 @@ class MetricsConfig:
             ConfigOptions.retry_jitter_min: 0,
             ConfigOptions.retry_jitter_max: 10,
             ConfigOptions.max_requests_to_buffer: 1000,
-            ConfigOptions.content_encoding: 'deflate',
-            ConfigOptions.content_type: 'application/vnd.sumologic.carbon2',
+            ConfigOptions.content_encoding: "deflate",
+            ConfigOptions.content_type: "application/vnd.sumologic.carbon2",
             ConfigOptions.shutdown_max_wait: 5,
             ConfigOptions.add_metric_dimension: True,
-            ConfigOptions.metric_dimension_separator: '.',
+            ConfigOptions.metric_dimension_separator: ".",
         }
 
     def parse_config(self, config):
@@ -85,38 +91,53 @@ class MetricsConfig:
                     url = child.values[0]
                     self.conf[child.key] = url
                     validate_non_empty(url, child.key)
-                elif child.key in [ConfigOptions.dimension_tags, ConfigOptions.meta_tags]:
+                elif child.key in [
+                    ConfigOptions.dimension_tags,
+                    ConfigOptions.meta_tags,
+                ]:
                     self._parse_tags(child)
-                elif child.key in [ConfigOptions.source_name, ConfigOptions.host_name,
-                                   ConfigOptions.source_category]:
+                elif child.key in [
+                    ConfigOptions.source_name,
+                    ConfigOptions.host_name,
+                    ConfigOptions.source_category,
+                ]:
                     _s = child.values[0]
                     validate_non_empty(_s, child.key)
-                    validate_string_type(_s, child.key, 'Value', 'Key')
+                    validate_string_type(_s, child.key, "Value", "Key")
                     self.conf[child.key] = _s
                 elif child.key == ConfigOptions.http_post_interval:
                     _f = float(child.values[0])
                     validate_positive(_f, child.key)
                     self.conf[child.key] = _f
-                elif child.key in [ConfigOptions.max_batch_size, ConfigOptions.max_batch_interval,
-                                   ConfigOptions.retry_max_attempts, ConfigOptions.retry_max_delay,
-                                   ConfigOptions.retry_backoff,
-                                   ConfigOptions.max_requests_to_buffer]:
+                elif child.key in [
+                    ConfigOptions.max_batch_size,
+                    ConfigOptions.max_batch_interval,
+                    ConfigOptions.retry_max_attempts,
+                    ConfigOptions.retry_max_delay,
+                    ConfigOptions.retry_backoff,
+                    ConfigOptions.max_requests_to_buffer,
+                ]:
                     _i = int(child.values[0])
                     validate_positive(_i, child.key)
                     self.conf[child.key] = _i
-                elif child.key in [ConfigOptions.retry_initial_delay,
-                                   ConfigOptions.retry_jitter_min, ConfigOptions.retry_jitter_max]:
+                elif child.key in [
+                    ConfigOptions.retry_initial_delay,
+                    ConfigOptions.retry_jitter_min,
+                    ConfigOptions.retry_jitter_max,
+                ]:
                     _i = int(child.values[0])
                     validate_non_negative(_i, child.key)
                     self.conf[child.key] = _i
                 elif child.key == ConfigOptions.content_encoding:
                     _s = child.values[0]
                     validate_non_empty(_s, child.key)
-                    validate_string_type(_s, child.key, 'Value', 'Key')
+                    validate_string_type(_s, child.key, "Value", "Key")
                     content_encoding = _s.lower()
                     if content_encoding not in self._content_encoding_set:
-                        raise Exception('Unknown ContentEncoding %s specified. ContentEncoding '
-                                        'must be deflate, gzip, or none' % _s)
+                        raise Exception(
+                            "Unknown ContentEncoding %s specified. ContentEncoding "
+                            "must be deflate, gzip, or none" % _s
+                        )
                     self.conf[child.key] = content_encoding
                 elif child.key == ConfigOptions.add_metric_dimension:
                     _b = child.values[0]
@@ -124,43 +145,53 @@ class MetricsConfig:
                     self.conf[child.key] = _b
                 elif child.key == ConfigOptions.metric_dimension_separator:
                     _s = child.values[0]
-                    validate_string_type(_s, child.key, 'Value', 'Key')
+                    validate_string_type(_s, child.key, "Value", "Key")
                     self.conf[child.key] = _s
                 else:
-                    self.collectd.warning('Unknown configuration %s, ignored.' % child.key)
+                    self.collectd.warning(
+                        "Unknown configuration %s, ignored." % child.key
+                    )
         except Exception as e:
-            self.collectd.error('Failed to parse configurations due to %s' % str(e))
+            self.collectd.error("Failed to parse configurations due to %s" % str(e))
             raise e
 
         if ConfigOptions.url not in self.conf:
-            raise Exception('Specify %s in collectd.conf.' % ConfigOptions.url)
+            raise Exception("Specify %s in collectd.conf." % ConfigOptions.url)
 
         # Set metric dimension separator to None if we do not want to add it
-        if ConfigOptions.add_metric_dimension not in self.conf \
-            or not self.conf[ConfigOptions.add_metric_dimension]:
+        if (
+            ConfigOptions.add_metric_dimension not in self.conf
+            or not self.conf[ConfigOptions.add_metric_dimension]
+        ):
             self.conf[ConfigOptions.metric_dimension_separator] = None
 
         http_post_interval = self.conf[ConfigOptions.http_post_interval]
         max_batch_interval = self.conf[ConfigOptions.max_batch_interval]
 
         if http_post_interval > max_batch_interval:
-            raise Exception('Specify HttpPostInterval %f as float between 0 and '
-                            'MaxBatchInterval %d' %(http_post_interval, max_batch_interval))
+            raise Exception(
+                "Specify HttpPostInterval %f as float between 0 and "
+                "MaxBatchInterval %d" % (http_post_interval, max_batch_interval)
+            )
 
         retry_jitter_min = self.conf[ConfigOptions.retry_jitter_min]
         retry_jitter_max = self.conf[ConfigOptions.retry_jitter_max]
 
         if retry_jitter_min > retry_jitter_max:
-            raise Exception('Specify RetryJitterMin %d to be less or equal to RetryJitterMax %d' %
-                            (retry_jitter_min, retry_jitter_max))
+            raise Exception(
+                "Specify RetryJitterMin %d to be less or equal to RetryJitterMax %d"
+                % (retry_jitter_min, retry_jitter_max)
+            )
 
-        self.collectd.info('Updated MetricsConfig %s with config file %s ' % (self.conf, config))
+        self.collectd.info(
+            "Updated MetricsConfig %s with config file %s " % (self.conf, config)
+        )
 
     # parse dimension_tags/meta_tags specified in collectd.conf
     def _parse_tags(self, child):
         if len(child.values) % 2 != 0:
-            raise Exception('Missing tags key/value in options %s.' % str(child.values))
+            raise Exception("Missing tags key/value in options %s." % str(child.values))
 
         self.conf[child.key] = zip(*(iter(child.values),) * 2)
 
-        self.collectd.info('Parsed %s tags %s' % (child.key, self.conf[child.key]))
+        self.collectd.info("Parsed %s tags %s" % (child.key, self.conf[child.key]))

--- a/sumologic_collectd_metrics/metrics_converter.py
+++ b/sumologic_collectd_metrics/metrics_converter.py
@@ -17,8 +17,19 @@ class IntrinsicKeys(object):
 
 
 # reserved keywords are case-insensitive
-_reserved_keywords = frozenset(['_sourcehost', '_sourcename', '_sourcecategory', '_collectorid',
-                                '_collector', '_source', '_sourceid', '_contenttype', '_rawname'])
+_reserved_keywords = frozenset(
+    [
+        "_sourcehost",
+        "_sourcename",
+        "_sourcecategory",
+        "_collectorid",
+        "_collector",
+        "_source",
+        "_sourceid",
+        "_contenttype",
+        "_rawname",
+    ]
+)
 
 
 def gen_tag(key, value):
@@ -28,23 +39,25 @@ def gen_tag(key, value):
     key = sanitize_field(key)
     value = sanitize_field(value)
     if not key:
-        raise Exception('Key for value %s cannot be empty' % value)
+        raise Exception("Key for value %s cannot be empty" % value)
 
     if key.lower() in _reserved_keywords:
-        raise Exception('Key %s (case-insensitive) must not contain reserved keywords %s' %
-                        (key, _reserved_keywords))
+        raise Exception(
+            "Key %s (case-insensitive) must not contain reserved keywords %s"
+            % (key, _reserved_keywords)
+        )
 
     if not value:
-        return ''
+        return ""
 
-    return key + '=' + value
+    return key + "=" + value
 
 
 def _remove_empty_tags(tags):
     return [tag for tag in tags if tag]
 
 
-def tags_to_str(tags, sep=' '):
+def tags_to_str(tags, sep=" "):
     """
     Convert list of tags to a single string
     """
@@ -63,25 +76,37 @@ def _gen_metric(dimension_tags, meta_tags, value, timestamp):
     """
 
     if not meta_tags:
-        return '%s  %f %i' % (tags_to_str(dimension_tags), value, timestamp)
+        return "%s  %f %i" % (tags_to_str(dimension_tags), value, timestamp)
 
-
-    return '%s  %s %f %i' % (tags_to_str(dimension_tags),
-                             tags_to_str(meta_tags), value, timestamp)
+    return "%s  %s %f %i" % (
+        tags_to_str(dimension_tags),
+        tags_to_str(meta_tags),
+        value,
+        timestamp,
+    )
 
 
 # Generate dimension tags
 def _gen_dimension_tags(data, ds_name, ds_type):
 
-    tags = [gen_tag(key, getattr(data, key)) for key in
-            [IntrinsicKeys.host, IntrinsicKeys.plugin, IntrinsicKeys.plugin_instance,
-                IntrinsicKeys.type, IntrinsicKeys.type_instance]] + \
-            [gen_tag(IntrinsicKeys.ds_name, ds_name),
-            gen_tag(IntrinsicKeys.ds_type, ds_type)]
+    tags = [
+        gen_tag(key, getattr(data, key))
+        for key in [
+            IntrinsicKeys.host,
+            IntrinsicKeys.plugin,
+            IntrinsicKeys.plugin_instance,
+            IntrinsicKeys.type,
+            IntrinsicKeys.type_instance,
+        ]
+    ] + [
+        gen_tag(IntrinsicKeys.ds_name, ds_name),
+        gen_tag(IntrinsicKeys.ds_type, ds_type),
+    ]
 
     dimension_tags = _remove_empty_tags(tags)
 
     return dimension_tags
+
 
 def _gen_metric_dimension(data, sep):
     """
@@ -93,9 +118,10 @@ def _gen_metric_dimension(data, sep):
     return [
         gen_tag(
             IntrinsicKeys.metric,
-            sep.join(v for v in (data.type, data.type_instance) if v)
-            )
-        ]
+            sep.join(v for v in (data.type, data.type_instance) if v),
+        )
+    ]
+
 
 def convert_to_metrics(data, data_set, sep):
     """

--- a/sumologic_collectd_metrics/metrics_sender.py
+++ b/sumologic_collectd_metrics/metrics_sender.py
@@ -4,13 +4,16 @@ try:
     from StringIO import StringIO as CompatibleIO
 except ImportError:
     from io import BytesIO as CompatibleIO
+
 import gzip
 import zlib
+
 import requests
 from retry.api import retry_call
+
 from .metrics_config import ConfigOptions
-from .metrics_util import RecoverableException
 from .metrics_converter import gen_tag, tags_to_str
+from .metrics_util import RecoverableException
 from .timer import Timer
 
 
@@ -19,14 +22,14 @@ class HeaderKeys(object):
     Http header keys
     """
 
-    content_type = 'Content-Type'
-    content_encoding = 'Content-Encoding'
-    x_sumo_source = 'X-Sumo-Name'
-    x_sumo_host = 'X-Sumo-Host'
-    x_sumo_category = 'X-Sumo-Category'
-    x_sumo_dimensions = 'X-Sumo-Dimensions'
-    x_sumo_metadata = 'X-Sumo-Metadata'
-    x_sumo_client = 'X-Sumo-Client'
+    content_type = "Content-Type"
+    content_encoding = "Content-Encoding"
+    x_sumo_source = "X-Sumo-Name"
+    x_sumo_host = "X-Sumo-Host"
+    x_sumo_category = "X-Sumo-Category"
+    x_sumo_dimensions = "X-Sumo-Dimensions"
+    x_sumo_metadata = "X-Sumo-Metadata"
+    x_sumo_client = "X-Sumo-Client"
 
 
 class MetricsSender(Timer):
@@ -40,7 +43,9 @@ class MetricsSender(Timer):
         """
 
         self.collectd = collectd
-        Timer.__init__(self, conf[ConfigOptions.http_post_interval], self._request_scheduler)
+        Timer.__init__(
+            self, conf[ConfigOptions.http_post_interval], self._request_scheduler
+        )
         self.conf = conf
         self.buffer = met_buf
         self.http_headers = self._build_header()
@@ -56,8 +61,10 @@ class MetricsSender(Timer):
             if batch is not None:
                 self._send_request_with_retries(batch)
         except Exception as e:
-            self.collectd.warning('Sending metrics batch %s failed after all retries due to %s. '
-                                  'Put metrics batch into failed metrics buffer.' % (batch, str(e)))
+            self.collectd.warning(
+                "Sending metrics batch %s failed after all retries due to %s. "
+                "Put metrics batch into failed metrics buffer." % (batch, str(e))
+            )
             self.buffer.put_failed_batch(batch)
 
     # Send metrics batch via https with error handling
@@ -65,55 +72,75 @@ class MetricsSender(Timer):
     def _send_request(self, headers, body):
 
         try:
-            self.collectd.debug('Sending https request with headers %s, body %s' % (headers, body))
+            self.collectd.debug(
+                "Sending https request with headers %s, body %s" % (headers, body)
+            )
 
-            response = requests.post(self.conf[ConfigOptions.url],
-                                     data=self.encode_body(body), headers=headers)
+            response = requests.post(
+                self.conf[ConfigOptions.url],
+                data=self.encode_body(body),
+                headers=headers,
+            )
 
-            self.collectd.info('Sent https request with batch_size=%d got response_code=%s' %
-                               (len(body), response.status_code))
+            self.collectd.info(
+                "Sent https request with batch_size=%d got response_code=%s"
+                % (len(body), response.status_code)
+            )
         except requests.exceptions.HTTPError as e:
-            self.fail_with_recoverable_exception('An HTTP error occurred', body, e)
+            self.fail_with_recoverable_exception("An HTTP error occurred", body, e)
         except requests.exceptions.ConnectionError as e:
-            self.fail_with_recoverable_exception('A Connection error occurred', body, e)
+            self.fail_with_recoverable_exception("A Connection error occurred", body, e)
         except requests.exceptions.Timeout as e:
-            self.fail_with_recoverable_exception('The request timed out', body, e)
+            self.fail_with_recoverable_exception("The request timed out", body, e)
         except requests.exceptions.TooManyRedirects as e:
-            self.fail_with_recoverable_exception('Too many redirects', body, e)
+            self.fail_with_recoverable_exception("Too many redirects", body, e)
         except requests.exceptions.StreamConsumedError as e:
             self.fail_with_recoverable_exception(
-                'The content for this response was already consumed', body, e)
+                "The content for this response was already consumed", body, e
+            )
         except requests.exceptions.RetryError as e:
-            self.fail_with_recoverable_exception('Custom retries logic failed', body, e)
+            self.fail_with_recoverable_exception("Custom retries logic failed", body, e)
         except requests.exceptions.ChunkedEncodingError as e:
             self.fail_with_recoverable_exception(
-                'The server declared chunked encoding but sent an invalid chunk', body, e)
+                "The server declared chunked encoding but sent an invalid chunk",
+                body,
+                e,
+            )
         except requests.exceptions.ContentDecodingError as e:
-            self.fail_with_recoverable_exception('Failed to decode response', body, e)
+            self.fail_with_recoverable_exception("Failed to decode response", body, e)
         except requests.exceptions.URLRequired as e:
             self.fail_with_recoverable_exception(
-                'A valid URL is required to make a request', body, e)
+                "A valid URL is required to make a request", body, e
+            )
         except requests.exceptions.MissingSchema as e:
             self.fail_with_recoverable_exception(
-                'The URL schema (e.g. http or https) is missing', body, e)
+                "The URL schema (e.g. http or https) is missing", body, e
+            )
         except requests.exceptions.InvalidSchema as e:
-            self.fail_with_recoverable_exception('See schemas in defaults.py', body, e)
+            self.fail_with_recoverable_exception("See schemas in defaults.py", body, e)
         except requests.exceptions.InvalidURL as e:
-            self.fail_with_recoverable_exception('The URL provided was invalid', body, e)
+            self.fail_with_recoverable_exception(
+                "The URL provided was invalid", body, e
+            )
         except Exception as e:
-            self.fail_with_recoverable_exception('unknown exception', body, e)
+            self.fail_with_recoverable_exception("unknown exception", body, e)
 
     # Send http request with retries
     def _send_request_with_retries(self, batch):
 
-        retry_call(self._send_request, fargs=[self.http_headers, batch],
-                   exceptions=RecoverableException,
-                   tries=self.conf[ConfigOptions.retry_max_attempts],
-                   delay=self.conf[ConfigOptions.retry_initial_delay],
-                   max_delay=self.conf[ConfigOptions.retry_max_delay],
-                   backoff=self.conf[ConfigOptions.retry_backoff],
-                   jitter=(self.conf[ConfigOptions.retry_jitter_min],
-                           self.conf[ConfigOptions.retry_jitter_max]))
+        retry_call(
+            self._send_request,
+            fargs=[self.http_headers, batch],
+            exceptions=RecoverableException,
+            tries=self.conf[ConfigOptions.retry_max_attempts],
+            delay=self.conf[ConfigOptions.retry_initial_delay],
+            max_delay=self.conf[ConfigOptions.retry_max_delay],
+            backoff=self.conf[ConfigOptions.retry_backoff],
+            jitter=(
+                self.conf[ConfigOptions.retry_jitter_min],
+                self.conf[ConfigOptions.retry_jitter_max],
+            ),
+        )
 
     # Build http header
     def _build_header(self):
@@ -121,51 +148,58 @@ class MetricsSender(Timer):
         headers = {
             HeaderKeys.content_type: self.conf[ConfigOptions.content_type],
             HeaderKeys.content_encoding: self.conf[ConfigOptions.content_encoding],
-            HeaderKeys.x_sumo_client: 'collectd-plugin'
+            HeaderKeys.x_sumo_client: "collectd-plugin",
         }
 
         config_keys = self.conf.keys()
 
         # Add sumo specific header content
-        sumo_config_keys = [ConfigOptions.source_name, ConfigOptions.host_name,
-                            ConfigOptions.source_category]
-        sumo_header_keys = [HeaderKeys.x_sumo_source, HeaderKeys.x_sumo_host,
-                            HeaderKeys.x_sumo_category]
+        sumo_config_keys = [
+            ConfigOptions.source_name,
+            ConfigOptions.host_name,
+            ConfigOptions.source_category,
+        ]
+        sumo_header_keys = [
+            HeaderKeys.x_sumo_source,
+            HeaderKeys.x_sumo_host,
+            HeaderKeys.x_sumo_category,
+        ]
         for (config_key, header_key) in zip(sumo_config_keys, sumo_header_keys):
             if config_key in config_keys:
                 headers[header_key] = self.conf[config_key]
 
         # Add custom dimension_tags specified in conf
         if ConfigOptions.dimension_tags in config_keys:
-            headers[HeaderKeys.x_sumo_dimensions] = tags_to_str(self._gen_config_dimension_tags(),
-                                                                sep=',')
+            headers[HeaderKeys.x_sumo_dimensions] = tags_to_str(
+                self._gen_config_dimension_tags(), sep=","
+            )
 
         # Add custom meta_tags specified in conf
         if ConfigOptions.meta_tags in config_keys:
-            headers[HeaderKeys.x_sumo_metadata] = tags_to_str(self._gen_config_meta_tags(), sep=',')
+            headers[HeaderKeys.x_sumo_metadata] = tags_to_str(
+                self._gen_config_meta_tags(), sep=","
+            )
 
         return headers
 
     # Generate dimension_tags from config
     def _gen_config_dimension_tags(self):
 
-        return [gen_tag(k, v) for k, v in
-                self.conf[ConfigOptions.dimension_tags]]
+        return [gen_tag(k, v) for k, v in self.conf[ConfigOptions.dimension_tags]]
 
     # Generate meta_tags from config
     def _gen_config_meta_tags(self):
 
-        return [gen_tag(k, v) for k, v in
-                self.conf[ConfigOptions.meta_tags]]
+        return [gen_tag(k, v) for k, v in self.conf[ConfigOptions.meta_tags]]
 
     # Encode body with specified compress method gzip/deflate
     def encode_body(self, body):
-        body_str = '\n'.join(body).encode('utf-8')
+        body_str = "\n".join(body).encode("utf-8")
         content_encoding = self.conf[ConfigOptions.content_encoding]
-        if content_encoding == 'deflate':
+        if content_encoding == "deflate":
             return zlib.compress(body_str)
 
-        if content_encoding == 'gzip':
+        if content_encoding == "gzip":
             encoded_stream = CompatibleIO()
             with GzipFile(fileobj=encoded_stream, mode="w") as file:
                 file.write(body_str)
@@ -178,8 +212,10 @@ class MetricsSender(Timer):
         Warn about exception and raise RecoverableException
         """
 
-        self.collectd.warning(msg + ': Sending batch with size %s failed with recoverable '
-                                    'exception %s. Retrying' % (len(batch), str(e)))
+        self.collectd.warning(
+            msg + ": Sending batch with size %s failed with recoverable "
+            "exception %s. Retrying" % (len(batch), str(e))
+        )
         raise RecoverableException(e)
 
 
@@ -187,13 +223,13 @@ class MetricsSender(Timer):
 # https://mail.python.org/pipermail/tutor/2009-November/072957.html
 class GzipFile(gzip.GzipFile):
     def __enter__(self, *args):
-        if hasattr(gzip.GzipFile, '__enter__'):
+        if hasattr(gzip.GzipFile, "__enter__"):
             return gzip.GzipFile.__enter__(self)
 
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if hasattr(gzip.GzipFile, '__exit__'):
+        if hasattr(gzip.GzipFile, "__exit__"):
             return gzip.GzipFile.__exit__(self, exc_type, exc_value, traceback)
 
         return self.close()

--- a/sumologic_collectd_metrics/metrics_util.py
+++ b/sumologic_collectd_metrics/metrics_util.py
@@ -1,24 +1,24 @@
 # -*- coding: utf-8 -*-
 
 _reserved_symbols = {
-    ' ': '_',
-    '=': ':',
+    " ": "_",
+    "=": ":",
 }
 
 
 def validate_non_empty(value, key):
     if not value:
-        raise Exception('Value for key %s cannot be empty' % key)
+        raise Exception("Value for key %s cannot be empty" % key)
 
 
 def validate_positive(value, key):
     if not value > 0:
-        raise Exception('Value %s for key %s is not a positive number' % (value, key))
+        raise Exception("Value %s for key %s is not a positive number" % (value, key))
 
 
 def validate_non_negative(value, key):
     if value < 0:
-        raise Exception('Value %s for key %s is a negative number' % (value, key))
+        raise Exception("Value %s for key %s is a negative number" % (value, key))
 
 
 def validate_string_type(value, field, label1, label2):
@@ -27,8 +27,10 @@ def validate_string_type(value, field, label1, label2):
     """
 
     if not isinstance(value, str):
-        raise Exception('%s %s for %s %s must be string type. Type is %s' %
-                        (label1, value, label2, field, type(value)))
+        raise Exception(
+            "%s %s for %s %s must be string type. Type is %s"
+            % (label1, value, label2, field, type(value))
+        )
 
 
 def validate_boolean_type(field, value):
@@ -37,8 +39,10 @@ def validate_boolean_type(field, value):
     """
 
     if not isinstance(value, bool):
-        raise Exception('Value for %s must be boolean type, but it was "%s"(%s)' %
-                        (field, value, type(value)))
+        raise Exception(
+            'Value for %s must be boolean type, but it was "%s"(%s)'
+            % (field, value, type(value))
+        )
 
 
 def sanitize_field(value):

--- a/sumologic_collectd_metrics/timer.py
+++ b/sumologic_collectd_metrics/timer.py
@@ -15,9 +15,11 @@ class Timer:
         self.start_timer_lock = threading.Lock()
         self.run_count = 0
         self.run_count_reset = 60 / interval
-        if hasattr(self, 'collectd'):
-            self.collectd.info('Timer %s will report once a minute (every %s runs).' % (
-                self.__class__.__name__, self.run_count_reset))
+        if hasattr(self, "collectd"):
+            self.collectd.info(
+                "Timer %s will report once a minute (every %s runs)."
+                % (self.__class__.__name__, self.run_count_reset)
+            )
 
     def __del__(self):
         self.cancel_timer()
@@ -28,13 +30,14 @@ class Timer:
         """
 
         with self.start_timer_lock:
-            if hasattr(self, 'collectd'):
-                self.collectd.debug('Timer has been run: %s.' %
-                                    self.__class__.__name__)
+            if hasattr(self, "collectd"):
+                self.collectd.debug("Timer has been run: %s." % self.__class__.__name__)
             if self.run_count >= self.run_count_reset:
-                if hasattr(self, 'collectd'):
-                    self.collectd.info('Timer %s has run %s times.' % (
-                        self.__class__.__name__, self.run_count))
+                if hasattr(self, "collectd"):
+                    self.collectd.info(
+                        "Timer %s has run %s times."
+                        % (self.__class__.__name__, self.run_count)
+                    )
                 self.run_count = 0
             self.run_count += 1
 
@@ -45,15 +48,15 @@ class Timer:
         self.task()
 
     def cancel_timer(self):
-        if hasattr(self, 'collectd'):
-            self.collectd.debug('Timer has been canceled: %s.' %
-                                self.__class__.__name__)
+        if hasattr(self, "collectd"):
+            self.collectd.debug(
+                "Timer has been canceled: %s." % self.__class__.__name__
+            )
         if self.timer is not None:
             self.timer.cancel()
 
     def reset_timer(self):
-        if hasattr(self, 'collectd'):
-            self.collectd.debug('Timer has been reset: %s' %
-                                self.__class__.__name__)
+        if hasattr(self, "collectd"):
+            self.collectd.debug("Timer has been reset: %s" % self.__class__.__name__)
         self.cancel_timer()
         self.start_timer()

--- a/test/collectd/__init__.py
+++ b/test/collectd/__init__.py
@@ -1,7 +1,8 @@
-from . register import (register_config, register_init, register_write, register_shutdown)
+# Due to circular import problems in sumologic_collectd_metrics/__init__.py, this
+# import needs to happen before the Helper
+from .register import register_config  # isort: skip
 
-from . logger import (debug, info, warning, error)
-
-from . collectd_mock import CollecdMock
-
-from . helper import Helper
+from .collectd_mock import CollecdMock
+from .helper import Helper
+from .logger import debug, error, info, warning
+from .register import register_init, register_shutdown, register_write

--- a/test/collectd/collectd_config.py
+++ b/test/collectd/collectd_config.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
+
 class CollectdConfig:
     def __init__(self, children):
         self.children = children
 
     def children(self):
         return self.children
+
 
 class ConfigNode:
     def __init__(self, key, values):

--- a/test/collectd/collectd_mock.py
+++ b/test/collectd/collectd_mock.py
@@ -5,8 +5,11 @@ from . import logger, register
 
 class CollecdMock:
     TYPES = {
-        'test_type': [('test_ds_name', 'test_ds_type', 0, None)],
-        'test_type_2': [('test_ds_name1', 'test_ds_type1', 0, None), ('test_ds_name2', 'test_ds_type2', 0, None)],
+        "test_type": [("test_ds_name", "test_ds_type", 0, None)],
+        "test_type_2": [
+            ("test_ds_name1", "test_ds_type1", 0, None),
+            ("test_ds_name2", "test_ds_type2", 0, None),
+        ],
     }
 
     def debug(self, msg):

--- a/test/collectd/helper.py
+++ b/test/collectd/helper.py
@@ -4,8 +4,7 @@ import os
 
 from sumologic_collectd_metrics.metrics_batcher import MetricsBatcher
 from sumologic_collectd_metrics.metrics_buffer import MetricsBuffer
-from sumologic_collectd_metrics.metrics_config import (ConfigOptions,
-                                                       MetricsConfig)
+from sumologic_collectd_metrics.metrics_config import ConfigOptions, MetricsConfig
 from sumologic_collectd_metrics.metrics_sender import MetricsSender
 from sumologic_collectd_metrics.metrics_writer import MetricsWriter
 
@@ -17,7 +16,7 @@ cwd = os.getcwd()
 
 class Helper:
 
-    url = 'http://www.sumologic.com'
+    url = "http://www.sumologic.com"
 
     def __init__(self):
         config = Helper.default_config()

--- a/test/collectd/logger.py
+++ b/test/collectd/logger.py
@@ -1,16 +1,17 @@
 # -*- coding: utf-8 -*-
 
+
 def debug(msg):
-    print('collect.debug: %s' % msg)
+    print("collect.debug: %s" % msg)
 
 
 def info(msg):
-    print('collect.info: %s' % msg)
+    print("collect.info: %s" % msg)
 
 
 def warning(msg):
-    print('collect.warning: %s' % msg)
+    print("collect.warning: %s" % msg)
 
 
 def error(msg):
-    print('collect.error: %s' % msg)
+    print("collect.error: %s" % msg)

--- a/test/collectd/register.py
+++ b/test/collectd/register.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+
 def register_config(func):
     pass
 

--- a/test/collectd/values.py
+++ b/test/collectd/values.py
@@ -1,33 +1,35 @@
 # -*- coding: utf-8 -*-
 
+
 class Constants:
-    host = 'test_host'
-    plugin = 'test_plugin'
-    plugin_instance = 'test_plugin_instance'
-    type = 'test_type'
-    type_instance = 'test_type_instance'
-    meta = {'test_meta_key': 'test_meta_val'}
-    interval = 10,
+    host = "test_host"
+    plugin = "test_plugin"
+    plugin_instance = "test_plugin_instance"
+    type = "test_type"
+    type_instance = "test_type_instance"
+    meta = {"test_meta_key": "test_meta_val"}
+    interval = (10,)
     time = 1501775008
     values = [3.14]
-    ds_names = ['test_ds_name']
-    ds_types = ['test_ds_type']
+    ds_names = ["test_ds_name"]
+    ds_types = ["test_ds_type"]
 
 
 class Values:
-
-    def __init__(self,
-                 host=Constants.host,
-                 plugin=Constants.plugin,
-                 plugin_instance=Constants.plugin_instance,
-                 type=Constants.type,
-                 type_instance=Constants.type_instance,
-                 meta=Constants.meta,
-                 interval=Constants.interval,
-                 time=Constants.time,
-                 values=Constants.values,
-                 ds_names=Constants.ds_names,
-                 ds_types=Constants.ds_types):
+    def __init__(
+        self,
+        host=Constants.host,
+        plugin=Constants.plugin,
+        plugin_instance=Constants.plugin_instance,
+        type=Constants.type,
+        type_instance=Constants.type_instance,
+        meta=Constants.meta,
+        interval=Constants.interval,
+        time=Constants.time,
+        values=Constants.values,
+        ds_names=Constants.ds_names,
+        ds_types=Constants.ds_types,
+    ):
 
         self.host = host
         self.plugin = plugin
@@ -41,7 +43,7 @@ class Values:
         self.ds_names = ds_names
         self.ds_types = ds_types
 
-    def metrics_str(self, sep='.'):
+    def metrics_str(self, sep="."):
         """
         Builds metric string. If sep is not None,
         it includes metric dimension using sep as separator
@@ -49,20 +51,47 @@ class Values:
         metrics = []
         i = 0
         if sep is None:
-            metric = ''
+            metric = ""
         else:
-            metric = ' metric=%s' %(sep.join(v for v in (self.type, self.type_instance) if v))
+            metric = " metric=%s" % (
+                sep.join(v for v in (self.type, self.type_instance) if v)
+            )
 
         for (ds_name, ds_type) in zip(self.ds_names, self.ds_types):
             if not self.meta:
-                metrics.append('host=%s plugin=%s plugin_instance=%s type=%s type_instance=%s '
-                               'ds_name=%s ds_type=%s%s  %f %d' %
-                               (self.host, self.plugin, self.plugin_instance, self.type, self.type_instance,
-                                ds_name, ds_type, metric, self.values[i], self.time))
+                metrics.append(
+                    "host=%s plugin=%s plugin_instance=%s type=%s type_instance=%s "
+                    "ds_name=%s ds_type=%s%s  %f %d"
+                    % (
+                        self.host,
+                        self.plugin,
+                        self.plugin_instance,
+                        self.type,
+                        self.type_instance,
+                        ds_name,
+                        ds_type,
+                        metric,
+                        self.values[i],
+                        self.time,
+                    )
+                )
             else:
-                metrics.append('host=%s plugin=%s plugin_instance=%s type=%s type_instance=%s '
-                               'ds_name=%s ds_type=%s%s  test_meta_key=%s %f %d' %
-                               (self.host, self.plugin, self.plugin_instance, self.type, self.type_instance,
-                                ds_name, ds_type, metric, self.meta['test_meta_key'], self.values[i], self.time))
+                metrics.append(
+                    "host=%s plugin=%s plugin_instance=%s type=%s type_instance=%s "
+                    "ds_name=%s ds_type=%s%s  test_meta_key=%s %f %d"
+                    % (
+                        self.host,
+                        self.plugin,
+                        self.plugin_instance,
+                        self.type,
+                        self.type_instance,
+                        ds_name,
+                        ds_type,
+                        metric,
+                        self.meta["test_meta_key"],
+                        self.values[i],
+                        self.time,
+                    )
+                )
             i += 1
         return metrics

--- a/test/requests/__init__.py
+++ b/test/requests/__init__.py
@@ -1,3 +1,2 @@
-from . post import (post, post_response_decider, mock_server, mock_response)
-
 from . import exceptions
+from .post import mock_response, mock_server, post, post_response_decider

--- a/test/requests/exceptions.py
+++ b/test/requests/exceptions.py
@@ -11,13 +11,13 @@ class RequestException(IOError):
 
     def __init__(self, *args, **kwargs):
         """Initialize RequestException with `request` and `response` objects."""
-        response = kwargs.pop('response', None)
+        response = kwargs.pop("response", None)
         self.response = response
-        self.request = kwargs.pop('request', None)
-        if (response is not None and not self.request and
-                hasattr(response, 'request')):
+        self.request = kwargs.pop("request", None)
+        if response is not None and not self.request and hasattr(response, "request"):
             self.request = self.response.request
         super(RequestException, self).__init__(*args, **kwargs)
+
 
 class HTTPError(RequestException):
     """An HTTP error occurred."""
@@ -101,14 +101,17 @@ class UnrewindableBodyError(RequestException):
 
 class RequestsWarning(Warning):
     """Base warning for Requests."""
+
     pass
 
 
 class FileModeWarning(RequestsWarning, DeprecationWarning):
     """A file was opened in text mode, but Requests determined its binary length."""
+
     pass
 
 
 class RequestsDependencyWarning(RequestsWarning):
     """An imported dependency doesn't match the expected version range."""
+
     pass

--- a/test/requests/post.py
+++ b/test/requests/post.py
@@ -1,27 +1,34 @@
 # -*- coding: utf-8 -*-
 
+
 class PostResponseDecider:
     def __init__(self):
         self.raise_recoverable_exception = False
         self.raise_unrecoverable_exception = False
         self.exception = None
         self.stop_raise_exception_after = 0
-        self.current_retry_number=0
+        self.current_retry_number = 0
 
     def reset(self):
         self.raise_recoverable_exception = False
         self.raise_unrecoverable_exception = False
         self.exception = None
         self.stop_raise_exception_after = 0
-        self.current_retry_number=0
+        self.current_retry_number = 0
 
-    def set(self, raise_http_error=False, raise_exception=False, exception=None,
-            stop_raise_exception_after=0, current_retry_number=0):
+    def set(
+        self,
+        raise_http_error=False,
+        raise_exception=False,
+        exception=None,
+        stop_raise_exception_after=0,
+        current_retry_number=0,
+    ):
         self.raise_recoverable_exception = raise_http_error
         self.raise_unrecoverable_exception = raise_exception
         self.exception = exception
         self.stop_raise_exception_after = stop_raise_exception_after
-        self.current_retry_number=current_retry_number
+        self.current_retry_number = current_retry_number
 
 
 class MockServer:
@@ -39,13 +46,14 @@ class MockServer:
 class MockResponse:
     def __init__(self):
         self.status_code = 200
-        self.request = 'test_request'
+        self.request = "test_request"
 
     def reset(self):
         self.status_code = 200
 
     def set(self, status_code):
         self.status_code = status_code
+
 
 post_response_decider = PostResponseDecider()
 mock_server = MockServer()
@@ -54,13 +62,15 @@ mock_response = MockResponse()
 
 def post(url, data, headers):
     if post_response_decider.raise_recoverable_exception:
-        if (post_response_decider.current_retry_number >=
-                post_response_decider.stop_raise_exception_after):
+        if (
+            post_response_decider.current_retry_number
+            >= post_response_decider.stop_raise_exception_after
+        ):
             return success(url, data, headers)
         else:
             raise_exception()
     elif post_response_decider.raise_unrecoverable_exception:
-            raise_exception()
+        raise_exception()
     else:
         return success(url, data, headers)
 
@@ -68,7 +78,7 @@ def post(url, data, headers):
 def raise_exception():
     exception = post_response_decider.exception
     exception.response = mock_response
-    exception.message = 'Http error with error code %s ' % mock_response.status_code
+    exception.message = "Http error with error code %s " % mock_response.status_code
     post_response_decider.current_retry_number += 1
     raise exception
 

--- a/test/test_metrics_batcher.py
+++ b/test/test_metrics_batcher.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import time
+
 from collectd import Helper
 
 
@@ -10,7 +11,7 @@ def test_metrics_batcher_max_size():
     met_batcher = Helper.get_batcher(max_batch_size, 60.0, met_buffer)
 
     for i in range(50):
-        met_batcher.push_item('item_%s' % i)
+        met_batcher.push_item("item_%s" % i)
 
     assert met_buffer.pending_queue.qsize() == 5
     for i in range(5):
@@ -18,7 +19,7 @@ def test_metrics_batcher_max_size():
 
         expected_batch = []
         for j in range(max_batch_size):
-            expected_batch.append('item_%s' % (i * max_batch_size + j))
+            expected_batch.append("item_%s" % (i * max_batch_size + j))
 
         assert len(batch) == max_batch_size
         assert batch == expected_batch
@@ -33,7 +34,7 @@ def test_metrics_batcher_max_interval():
 
     for i in range(50):
         time.sleep(0.010)
-        met_batcher.push_item('item_%s' % i)
+        met_batcher.push_item("item_%s" % i)
 
     while not met_buffer.pending_queue.empty():
         batch = met_buffer.pending_queue.get()
@@ -48,7 +49,7 @@ def test_metrics_batcher_locks():
     met_batcher = Helper.get_batcher(max_batch_size, 0.100, met_buffer)
 
     for i in range(50):
-        met_batcher.push_item('item_%s' % i)
+        met_batcher.push_item("item_%s" % i)
 
     assert met_buffer.pending_queue.qsize() == 25
     for i in range(25):
@@ -56,7 +57,7 @@ def test_metrics_batcher_locks():
 
         expected_batch = []
         for j in range(max_batch_size):
-            expected_batch.append('item_%s' % (i * max_batch_size + j))
+            expected_batch.append("item_%s" % (i * max_batch_size + j))
 
         assert len(batch) == max_batch_size
         assert batch == expected_batch

--- a/test/test_metrics_buffer.py
+++ b/test/test_metrics_buffer.py
@@ -6,17 +6,17 @@ from collectd import Helper
 def test_get_batch_processing_queue_empty():
     met_buffer = Helper.default_buffer()
     for i in range(10):
-        met_buffer.put_pending_batch(['batch_%s' % i])
+        met_buffer.put_pending_batch(["batch_%s" % i])
 
     for i in range(10):
-        assert met_buffer.get_batch() == ['batch_%s' % i]
+        assert met_buffer.get_batch() == ["batch_%s" % i]
 
 
 def test_get_batch_pending_queue_empty():
     met_buffer = Helper.default_buffer()
-    met_buffer.processing_queue.put(['batch_0'])
+    met_buffer.processing_queue.put(["batch_0"])
 
-    assert met_buffer.get_batch() == ['batch_0']
+    assert met_buffer.get_batch() == ["batch_0"]
     assert met_buffer.get_batch() is None
 
 
@@ -28,49 +28,49 @@ def test_get_batch_both_queue_empty():
 def test_get_batch_both_queue_nonempty():
     met_buffer = Helper.default_buffer()
     for i in range(10):
-        met_buffer.put_pending_batch(['batch_%s' % i])
-    met_buffer.processing_queue.put(['batch_0'])
+        met_buffer.put_pending_batch(["batch_%s" % i])
+    met_buffer.processing_queue.put(["batch_0"])
 
-    assert met_buffer.get_batch() == ['batch_0']
+    assert met_buffer.get_batch() == ["batch_0"]
     for i in range(10):
-        assert met_buffer.pending_queue.get() == ['batch_%s' % i]
+        assert met_buffer.pending_queue.get() == ["batch_%s" % i]
 
 
 def test_put_pending_batch_queue_full():
     met_buffer = Helper.default_buffer()
     for i in range(20):
-        met_buffer.put_pending_batch(['batch_%s' % i])
+        met_buffer.put_pending_batch(["batch_%s" % i])
 
     for i in range(10, 20):
-        assert met_buffer.pending_queue.get() == ['batch_%s' % i]
+        assert met_buffer.pending_queue.get() == ["batch_%s" % i]
 
 
 def test_put_pending_batch_queue_not_full():
     met_buffer = Helper.default_buffer()
     for i in range(10):
-        met_buffer.put_pending_batch(['batch_%s' % i])
+        met_buffer.put_pending_batch(["batch_%s" % i])
 
     for i in range(10):
-        assert met_buffer.pending_queue.get() == ['batch_%s' % i]
+        assert met_buffer.pending_queue.get() == ["batch_%s" % i]
 
 
 def test_put_failed_batch_queue_full():
     met_buffer = Helper.default_buffer()
     for i in range(10):
-        met_buffer.put_pending_batch(['batch_%s' % i])
-    met_buffer.put_failed_batch(['batch_%s' % 11])
+        met_buffer.put_pending_batch(["batch_%s" % i])
+    met_buffer.put_failed_batch(["batch_%s" % 11])
 
     assert met_buffer.processing_queue.empty()
     for i in range(10):
-        assert met_buffer.pending_queue.get() == ['batch_%s' % i]
+        assert met_buffer.pending_queue.get() == ["batch_%s" % i]
 
 
 def test_put_failed_batch_queue_not_full():
     met_buffer = Helper.default_buffer()
     for i in range(5):
-        met_buffer.put_pending_batch(['batch_%s' % i])
-    met_buffer.put_failed_batch(['batch_%s' % 11])
+        met_buffer.put_pending_batch(["batch_%s" % i])
+    met_buffer.put_failed_batch(["batch_%s" % 11])
 
-    assert met_buffer.processing_queue.get() == ['batch_%s' % 11]
+    assert met_buffer.processing_queue.get() == ["batch_%s" % 11]
     for i in range(5):
-        assert met_buffer.pending_queue.get() == ['batch_%s' % i]
+        assert met_buffer.pending_queue.get() == ["batch_%s" % i]

--- a/test/test_metrics_config.py
+++ b/test/test_metrics_config.py
@@ -3,11 +3,10 @@
 import os
 
 import pytest
-
 from collectd import CollecdMock, Helper
 from collectd.collectd_config import CollectdConfig, ConfigNode
-from sumologic_collectd_metrics.metrics_config import (ConfigOptions,
-                                                       MetricsConfig)
+
+from sumologic_collectd_metrics.metrics_config import ConfigOptions, MetricsConfig
 
 cwd = os.getcwd()
 
@@ -22,19 +21,23 @@ def test_parse_url():
 
 def test_parse_dimension_tags():
     met_config = Helper.default_config()
-    tags = ('dim_key1', 'dim_val1', 'dim_key2', 'dim_val2')
-    config = CollectdConfig([Helper.url_node(),
-                             tags_node(ConfigOptions.dimension_tags, tags)])
+    tags = ("dim_key1", "dim_val1", "dim_key2", "dim_val2")
+    config = CollectdConfig(
+        [Helper.url_node(), tags_node(ConfigOptions.dimension_tags, tags)]
+    )
     met_config.parse_config(config)
 
-    assert list(met_config.conf[ConfigOptions.dimension_tags]) == list(tuple_to_pair(tags))
+    assert list(met_config.conf[ConfigOptions.dimension_tags]) == list(
+        tuple_to_pair(tags)
+    )
 
 
 def test_parse_meta_tags():
     met_config = Helper.default_config()
-    tags = ('meta_key1', 'meta_val1', 'meta_key2', 'meta_val2')
-    config = CollectdConfig([Helper.url_node(),
-                             tags_node(ConfigOptions.meta_tags, tags)])
+    tags = ("meta_key1", "meta_val1", "meta_key2", "meta_val2")
+    config = CollectdConfig(
+        [Helper.url_node(), tags_node(ConfigOptions.meta_tags, tags)]
+    )
     met_config.parse_config(config)
 
     assert list(met_config.conf[ConfigOptions.meta_tags]) == list(tuple_to_pair(tags))
@@ -43,44 +46,52 @@ def test_parse_meta_tags():
 def test_parse_meta_tags_missing_value():
     with pytest.raises(Exception) as e:
         met_config = Helper.default_config()
-        tags = ('meta_key1', 'meta_val1', 'meta_key2')
-        config = CollectdConfig([Helper.url_node(),
-                                 tags_node(ConfigOptions.meta_tags, tags)])
+        tags = ("meta_key1", "meta_val1", "meta_key2")
+        config = CollectdConfig(
+            [Helper.url_node(), tags_node(ConfigOptions.meta_tags, tags)]
+        )
         met_config.parse_config(config)
 
-    assert "Missing tags key/value in options ('meta_key1', 'meta_val1', 'meta_key2')." in str(e)
+    assert (
+        "Missing tags key/value in options ('meta_key1', 'meta_val1', 'meta_key2')."
+        in str(e)
+    )
 
 
 def test_parse_http_post_interval():
     met_config = Helper.default_config()
-    http_post_interval = '0.5'
-    http_post_interval_node = ConfigNode(ConfigOptions.http_post_interval, [http_post_interval])
-    config = CollectdConfig([Helper.url_node(),
-                             http_post_interval_node])
+    http_post_interval = "0.5"
+    http_post_interval_node = ConfigNode(
+        ConfigOptions.http_post_interval, [http_post_interval]
+    )
+    config = CollectdConfig([Helper.url_node(), http_post_interval_node])
     met_config.parse_config(config)
 
-    assert met_config.conf[ConfigOptions.http_post_interval] == float(http_post_interval)
+    assert met_config.conf[ConfigOptions.http_post_interval] == float(
+        http_post_interval
+    )
 
 
 def test_parse_http_post_interval_exception():
     with pytest.raises(Exception) as e:
         met_config = Helper.default_config()
-        http_post_interval = '0'
-        http_post_interval_node = ConfigNode(ConfigOptions.http_post_interval, [http_post_interval])
-        config = CollectdConfig([Helper.url_node(),
-                                 http_post_interval_node])
+        http_post_interval = "0"
+        http_post_interval_node = ConfigNode(
+            ConfigOptions.http_post_interval, [http_post_interval]
+        )
+        config = CollectdConfig([Helper.url_node(), http_post_interval_node])
         met_config.parse_config(config)
 
-    assert 'Value 0.0 for key HttpPostInterval is not a positive number' in str(e)
+    assert "Value 0.0 for key HttpPostInterval is not a positive number" in str(e)
 
 
 def test_parse_string_config():
     met_config = Helper.default_config()
 
     configs = {
-        'source_name': 'test_source',
-        'host_name': 'test_host',
-        'source_category': 'test_category'
+        "source_name": "test_source",
+        "host_name": "test_host",
+        "source_category": "test_category",
     }
 
     Helper.parse_configs(met_config, configs)
@@ -94,15 +105,15 @@ def test_parse_int_config():
     met_config = Helper.default_config()
 
     configs = {
-        'max_batch_size': '10',
-        'max_batch_interval': '5',
-        'retry_initial_delay': '2',
-        'retry_max_attempts': '5',
-        'retry_max_delay': '10',
-        'retry_backoff': '3',
-        'retry_jitter_min': '1',
-        'retry_jitter_max': '5',
-        'max_requests_to_buffer': '100'
+        "max_batch_size": "10",
+        "max_batch_interval": "5",
+        "retry_initial_delay": "2",
+        "retry_max_attempts": "5",
+        "retry_max_delay": "10",
+        "retry_backoff": "3",
+        "retry_jitter_min": "1",
+        "retry_jitter_max": "5",
+        "max_requests_to_buffer": "100",
     }
 
     Helper.parse_configs(met_config, configs)
@@ -114,95 +125,83 @@ def test_parse_int_config():
 
 def test_parse_content_encoding():
 
-    deflate_config = {
-        'content_encoding': 'deflate'
-    }
-    gzip_config = {
-        'content_encoding': 'gzip'
-    }
-    none_config = {
-        'content_encoding': 'none'
-    }
+    deflate_config = {"content_encoding": "deflate"}
+    gzip_config = {"content_encoding": "gzip"}
+    none_config = {"content_encoding": "none"}
     configs = [deflate_config, gzip_config, none_config]
 
     for config in configs:
         met_config = Helper.default_config()
         Helper.parse_configs(met_config, config)
-        assert met_config.conf[ConfigOptions.content_encoding] == \
-               config['content_encoding']
+        assert (
+            met_config.conf[ConfigOptions.content_encoding]
+            == config["content_encoding"]
+        )
 
 
 def test_parse_unknown_content_encoding():
     with pytest.raises(Exception) as e:
         met_config = Helper.default_config()
-        unknown_config = {
-            'content_encoding': 'unknown'
-        }
+        unknown_config = {"content_encoding": "unknown"}
         Helper.parse_configs(met_config, unknown_config)
 
-    assert 'Unknown ContentEncoding unknown specified. ' \
-           'ContentEncoding must be deflate, gzip, or none' in str(e)
+    assert (
+        "Unknown ContentEncoding unknown specified. "
+        "ContentEncoding must be deflate, gzip, or none" in str(e)
+    )
 
 
 def test_parse_retry_config_values_positive():
     with pytest.raises(Exception) as e:
         met_config = Helper.default_config()
-        configs = {
-            'max_batch_size': '10',
-            'max_batch_interval': '-5'
-        }
+        configs = {"max_batch_size": "10", "max_batch_interval": "-5"}
         Helper.parse_configs(met_config, configs)
 
-    assert 'Value -5 for key MaxBatchInterval is not a positive number' in str(e)
+    assert "Value -5 for key MaxBatchInterval is not a positive number" in str(e)
 
 
 def test_parse_retry_config_values_non_negative():
     with pytest.raises(Exception) as e:
         met_config = Helper.default_config()
-        configs = {
-            'retry_initial_delay': '-1'
-        }
+        configs = {"retry_initial_delay": "-1"}
         Helper.parse_configs(met_config, configs)
 
-    assert 'Value -1 for key RetryInitialDelay is a negative number' in str(e)
+    assert "Value -1 for key RetryInitialDelay is a negative number" in str(e)
 
 
 def test_parse_retry_config_jitter_min_greater_than_max():
     with pytest.raises(Exception) as e:
         met_config = Helper.default_config()
-        configs = {
-            'retry_jitter_min': '2',
-            'retry_jitter_max': '1'
-        }
+        configs = {"retry_jitter_min": "2", "retry_jitter_max": "1"}
         Helper.parse_configs(met_config, configs)
 
-    assert 'Specify RetryJitterMin 2 to be less or equal to RetryJitterMax 1' in str(e)
+    assert "Specify RetryJitterMin 2 to be less or equal to RetryJitterMax 1" in str(e)
 
 
 def test_parse_unknown_config_option():
     met_config = Helper.default_config()
-    unknown_config = 'unknown_config'
-    unknown_config_node = ConfigNode('unknown_config', unknown_config)
+    unknown_config = "unknown_config"
+    unknown_config_node = ConfigNode("unknown_config", unknown_config)
     config = CollectdConfig([Helper.url_node(), unknown_config_node])
     met_config.parse_config(config)
 
-    assert hasattr(met_config, 'unknown_config') is False
+    assert hasattr(met_config, "unknown_config") is False
 
 
 def test_parse_string_exception():
     with pytest.raises(Exception) as e:
         met_config = Helper.default_config()
-        url_node = ConfigNode(ConfigOptions.url, [''])
+        url_node = ConfigNode(ConfigOptions.url, [""])
         config = CollectdConfig([url_node])
         met_config.parse_config(config)
 
-    assert 'Value for key URL cannot be empty' in str(e)
+    assert "Value for key URL cannot be empty" in str(e)
 
 
 def test_parse_int_exception():
     with pytest.raises(ValueError):
         met_config = Helper.default_config()
-        max_batch_size = ''
+        max_batch_size = ""
         max_batch_size_node = ConfigNode(ConfigOptions.max_batch_size, [max_batch_size])
         config = CollectdConfig([Helper.url_node(), max_batch_size_node])
         met_config.parse_config(config)
@@ -214,31 +213,32 @@ def test_no_url_exception():
         config = CollectdConfig([])
         met_config.parse_config(config)
 
-    assert 'Specify URL in collectd.conf' in str(e)
+    assert "Specify URL in collectd.conf" in str(e)
 
 
 def test_invalid_http_post_interval_exception():
     with pytest.raises(Exception) as e:
         met_config = Helper.default_config()
-        http_post_interval = '100.0'
-        http_post_interval_node = ConfigNode(ConfigOptions.http_post_interval, [http_post_interval])
-        config = CollectdConfig([Helper.url_node(),
-                                 http_post_interval_node])
+        http_post_interval = "100.0"
+        http_post_interval_node = ConfigNode(
+            ConfigOptions.http_post_interval, [http_post_interval]
+        )
+        config = CollectdConfig([Helper.url_node(), http_post_interval_node])
         met_config.parse_config(config)
 
-    assert 'Specify HttpPostInterval' in str(e)
+    assert "Specify HttpPostInterval" in str(e)
 
 
 def test_non_ascii_strings():
     met_config = Helper.default_config()
 
     configs = {
-        'source_name': '数据源',
+        "source_name": "数据源",
     }
 
     Helper.parse_configs(met_config, configs)
 
-    assert met_config.conf[ConfigOptions.source_name] == '数据源'
+    assert met_config.conf[ConfigOptions.source_name] == "数据源"
 
 
 def tags_node(key, values):

--- a/test/test_metrics_converter.py
+++ b/test/test_metrics_converter.py
@@ -1,98 +1,111 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-
 from collectd import CollecdMock
 from collectd.values import Values
 
-from sumologic_collectd_metrics.metrics_converter import (convert_to_metrics,
-                                                          gen_tag, tags_to_str)
+from sumologic_collectd_metrics.metrics_converter import (
+    convert_to_metrics,
+    gen_tag,
+    tags_to_str,
+)
 
 
 def test_gen_tag():
-    assert gen_tag('tag_key', 'tag_value') == 'tag_key=tag_value'
+    assert gen_tag("tag_key", "tag_value") == "tag_key=tag_value"
 
 
 def test_gen_tag_empty_value():
-    assert gen_tag('tag_key', '') == ''
+    assert gen_tag("tag_key", "") == ""
 
 
 def test_gen_tag_empty_key_exception():
     with pytest.raises(Exception) as e:
-        gen_tag('', 'tag_value')
+        gen_tag("", "tag_value")
 
-    assert 'Key for value tag_value cannot be empty' in str(e)
+    assert "Key for value tag_value cannot be empty" in str(e)
 
 
 def test_gen_tag_key_word_exception():
     with pytest.raises(Exception) as e:
-        gen_tag('_sourceId', 'tag_value')
+        gen_tag("_sourceId", "tag_value")
 
-    assert 'Key _sourceId (case-insensitive) must not contain reserved keywords' in str(e)
+    assert "Key _sourceId (case-insensitive) must not contain reserved keywords" in str(
+        e
+    )
 
 
 def test_gen_key_not_string_exception():
-    value = gen_tag(('tag_key', ), 'tag_value')
-    expected = '[(\'tag_key\',)=tag_value'
+    value = gen_tag(("tag_key",), "tag_value")
+    expected = "[('tag_key',)=tag_value"
 
     assert expected, value
 
 
 def test_gen_value_not_string_exception():
-    value = gen_tag(('tag_key', ), 1)
-    expected = 'tag_key=1'
+    value = gen_tag(("tag_key",), 1)
+    expected = "tag_key=1"
 
     assert expected, value
 
 
 def test_gen_value_reserved():
-    assert gen_tag('tag_key space=', 'tag_value=t st') == 'tag_key_space:=tag_value:t_st'
+    assert (
+        gen_tag("tag_key space=", "tag_value=t st") == "tag_key_space:=tag_value:t_st"
+    )
 
 
 def test_tags_to_str():
-    tags = ['tag_key1=tag_val1', 'tag_key2=tag_val2', 'tag_key3=tag_val3']
+    tags = ["tag_key1=tag_val1", "tag_key2=tag_val2", "tag_key3=tag_val3"]
     tag_str = tags_to_str(tags)
 
-    assert tag_str == 'tag_key1=tag_val1 tag_key2=tag_val2 tag_key3=tag_val3'
+    assert tag_str == "tag_key1=tag_val1 tag_key2=tag_val2 tag_key3=tag_val3"
 
 
 def test_tags_to_str_with_empty_tag():
-    tags = ['tag_key1=tag_val1', '', 'tag_key3=tag_val3']
+    tags = ["tag_key1=tag_val1", "", "tag_key3=tag_val3"]
     tag_str = tags_to_str(tags)
 
-    assert tag_str == 'tag_key1=tag_val1 tag_key3=tag_val3'
+    assert tag_str == "tag_key1=tag_val1 tag_key3=tag_val3"
 
 
 def test_tags_to_str_with_empty_tags():
     tags = []
     tag_str = tags_to_str(tags)
 
-    assert tag_str == ''
+    assert tag_str == ""
 
 
 def test_convert_to_metrics_single():
     data = Values()
-    dataset = CollecdMock().get_dataset('test_type')
+    dataset = CollecdMock().get_dataset("test_type")
     metrics = convert_to_metrics(data, dataset, None)
 
     assert metrics == data.metrics_str(None)
 
 
 def test_convert_to_metrics_multiple():
-    data = Values(type='test_type_2', values=[1.23, 4.56],
-                  ds_names=['test_ds_name1', 'test_ds_name2'],
-                  ds_types=['test_ds_type1', 'test_ds_type2'])
-    dataset = CollecdMock().get_dataset('test_type_2')
+    data = Values(
+        type="test_type_2",
+        values=[1.23, 4.56],
+        ds_names=["test_ds_name1", "test_ds_name2"],
+        ds_types=["test_ds_type1", "test_ds_type2"],
+    )
+    dataset = CollecdMock().get_dataset("test_type_2")
     metrics = convert_to_metrics(data, dataset, None)
 
     assert metrics == data.metrics_str(None)
 
 
 def test_convert_to_metrics_no_meta():
-    data = Values(type='test_type_2', meta={}, values=[1.23, 4.56],
-                  ds_names=['test_ds_name1', 'test_ds_name2'],
-                  ds_types=['test_ds_type1', 'test_ds_type2'])
-    dataset = CollecdMock().get_dataset('test_type_2')
+    data = Values(
+        type="test_type_2",
+        meta={},
+        values=[1.23, 4.56],
+        ds_names=["test_ds_name1", "test_ds_name2"],
+        ds_types=["test_ds_type1", "test_ds_type2"],
+    )
+    dataset = CollecdMock().get_dataset("test_type_2")
     metrics = convert_to_metrics(data, dataset, None)
 
     assert metrics == data.metrics_str(None)
@@ -100,7 +113,7 @@ def test_convert_to_metrics_no_meta():
 
 def test_convert_to_metrics_with_metric_dimension():
     data = Values()
-    dataset = CollecdMock().get_dataset('test_type')
-    metrics = convert_to_metrics(data, dataset, '_')
+    dataset = CollecdMock().get_dataset("test_type")
+    metrics = convert_to_metrics(data, dataset, "_")
 
-    assert metrics == data.metrics_str('_')
+    assert metrics == data.metrics_str("_")

--- a/test/test_metrics_sender.py
+++ b/test/test_metrics_sender.py
@@ -2,10 +2,12 @@
 
 import time
 import zlib
+
 import pytest
 import requests
 from collectd import Helper
 from collectd.collectd_config import CollectdConfig, ConfigNode
+
 from sumologic_collectd_metrics.metrics_config import ConfigOptions
 from sumologic_collectd_metrics.metrics_sender import HeaderKeys
 
@@ -15,7 +17,7 @@ def test_post_normal_no_additional_header():
     helper = Helper()
 
     for i in range(10):
-        met_buffer.put_pending_batch(['batch_%s' % i])
+        met_buffer.put_pending_batch(["batch_%s" % i])
 
     met_sender = Helper.get_sender(helper.conf, met_buffer)
 
@@ -25,25 +27,19 @@ def test_post_normal_no_additional_header():
     assert requests.mock_server.headers == {
         HeaderKeys.content_type: helper.conf[ConfigOptions.content_type],
         HeaderKeys.content_encoding: helper.conf[ConfigOptions.content_encoding],
-        HeaderKeys.x_sumo_client: 'collectd-plugin'
+        HeaderKeys.x_sumo_client: "collectd-plugin",
     }
     for i in range(10):
-        assert_utf8_equal(helper.conf, requests.mock_server.data[i], 'batch_%s' % i)
+        assert_utf8_equal(helper.conf, requests.mock_server.data[i], "batch_%s" % i)
 
     met_sender.cancel_timer()
 
 
 def test_post_different_content_encodings():
     met_buffer = Helper.get_buffer(10)
-    deflate_config = {
-        'content_encoding': 'deflate'
-    }
-    gzip_config = {
-        'content_encoding': 'gzip'
-    }
-    none_config = {
-        'content_encoding': 'none'
-    }
+    deflate_config = {"content_encoding": "deflate"}
+    gzip_config = {"content_encoding": "gzip"}
+    none_config = {"content_encoding": "none"}
     configs = [deflate_config, gzip_config, none_config]
 
     for config in configs:
@@ -51,13 +47,15 @@ def test_post_different_content_encodings():
         met_config = Helper.default_config()
         Helper.parse_configs(met_config, config)
         for i in range(10):
-            met_buffer.put_pending_batch(['batch_%s' % i])
+            met_buffer.put_pending_batch(["batch_%s" % i])
 
         met_sender = Helper.get_sender(met_config.conf, met_buffer)
         sleep_helper(10, 0.100, 100)
 
         for i in range(10):
-            assert_utf8_equal(met_config.conf, requests.mock_server.data[i], 'batch_%s' % i)
+            assert_utf8_equal(
+                met_config.conf, requests.mock_server.data[i], "batch_%s" % i
+            )
         met_sender.cancel_timer()
 
 
@@ -66,14 +64,14 @@ def test_post_normal_additional_keys():
     met_config = Helper.default_config()
 
     configs = {
-        'source_name': 'test_source',
-        'host_name': 'test_host',
-        'source_category': 'test_category'
+        "source_name": "test_source",
+        "host_name": "test_host",
+        "source_category": "test_category",
     }
     Helper.parse_configs(met_config, configs)
 
     for i in range(10):
-        met_buffer.put_pending_batch(['batch_%s' % i])
+        met_buffer.put_pending_batch(["batch_%s" % i])
 
     met_sender = Helper.get_sender(met_config.conf, met_buffer)
 
@@ -83,14 +81,14 @@ def test_post_normal_additional_keys():
     assert requests.mock_server.headers == {
         HeaderKeys.content_type: met_config.conf[ConfigOptions.content_type],
         HeaderKeys.content_encoding: met_config.conf[ConfigOptions.content_encoding],
-        HeaderKeys.x_sumo_client: 'collectd-plugin',
-        HeaderKeys.x_sumo_source: 'test_source',
-        HeaderKeys.x_sumo_host: 'test_host',
-        HeaderKeys.x_sumo_category: 'test_category'
+        HeaderKeys.x_sumo_client: "collectd-plugin",
+        HeaderKeys.x_sumo_source: "test_source",
+        HeaderKeys.x_sumo_host: "test_host",
+        HeaderKeys.x_sumo_category: "test_category",
     }
 
     for i in range(10):
-        assert_utf8_equal(met_config.conf, requests.mock_server.data[i], 'batch_%s' % i)
+        assert_utf8_equal(met_config.conf, requests.mock_server.data[i], "batch_%s" % i)
 
     met_sender.cancel_timer()
 
@@ -100,8 +98,8 @@ def test_post_normal_addition_dimensions_metadata():
     met_config = Helper.default_config()
 
     configs = {
-        'dimension_tags': ('dim_key1', 'dim_val1', 'dim_key2', 'dim_val2'),
-        'meta_tags': ('meta_key1', 'meta_val1', 'meta_key2', 'meta_val2')
+        "dimension_tags": ("dim_key1", "dim_val1", "dim_key2", "dim_val2"),
+        "meta_tags": ("meta_key1", "meta_val1", "meta_key2", "meta_val2"),
     }
     for (key, value) in configs.items():
         node = ConfigNode(getattr(ConfigOptions, key), value)
@@ -109,7 +107,7 @@ def test_post_normal_addition_dimensions_metadata():
         met_config.parse_config(config)
 
     for i in range(10):
-        met_buffer.put_pending_batch(['batch_%s' % i])
+        met_buffer.put_pending_batch(["batch_%s" % i])
 
     met_sender = Helper.get_sender(met_config.conf, met_buffer)
 
@@ -119,13 +117,13 @@ def test_post_normal_addition_dimensions_metadata():
     assert requests.mock_server.headers == {
         HeaderKeys.content_type: met_config.conf[ConfigOptions.content_type],
         HeaderKeys.content_encoding: met_config.conf[ConfigOptions.content_encoding],
-        HeaderKeys.x_sumo_client: 'collectd-plugin',
-        HeaderKeys.x_sumo_dimensions: 'dim_key1=dim_val1,dim_key2=dim_val2',
-        HeaderKeys.x_sumo_metadata: 'meta_key1=meta_val1,meta_key2=meta_val2',
+        HeaderKeys.x_sumo_client: "collectd-plugin",
+        HeaderKeys.x_sumo_dimensions: "dim_key1=dim_val1,dim_key2=dim_val2",
+        HeaderKeys.x_sumo_metadata: "meta_key1=meta_val1,meta_key2=meta_val2",
     }
 
     for i in range(10):
-        assert_utf8_equal(met_config.conf, requests.mock_server.data[i], 'batch_%s' % i)
+        assert_utf8_equal(met_config.conf, requests.mock_server.data[i], "batch_%s" % i)
 
     met_sender.cancel_timer()
 
@@ -134,14 +132,19 @@ def test_post_client_recoverable_http_error():
     error_codes = [404, 408, 429]
     for error_code in error_codes:
         reset_test_env()
-        exception_to_raise = requests.exceptions.HTTPError(requests.exceptions.RequestException())
+        exception_to_raise = requests.exceptions.HTTPError(
+            requests.exceptions.RequestException()
+        )
         requests.mock_response.status_code = error_codes
         met_buffer = Helper.get_buffer(10)
         met_config = Helper.default_config()
-        helper_test_post_recoverable_exception(met_config, met_buffer, exception_to_raise,
-                                               error_code, 5)
+        helper_test_post_recoverable_exception(
+            met_config, met_buffer, exception_to_raise, error_code, 5
+        )
         for i in range(10):
-            assert_utf8_equal(met_config.conf, requests.mock_server.data[i], 'batch_%s' % i)
+            assert_utf8_equal(
+                met_config.conf, requests.mock_server.data[i], "batch_%s" % i
+            )
 
 
 def test_post_server_recoverable_http_error():
@@ -149,66 +152,87 @@ def test_post_server_recoverable_http_error():
 
     for error_code in error_codes:
         reset_test_env()
-        exception_to_raise = requests.exceptions.HTTPError(requests.exceptions.RequestException())
+        exception_to_raise = requests.exceptions.HTTPError(
+            requests.exceptions.RequestException()
+        )
         requests.mock_response.status_code = error_code
         met_buffer = Helper.get_buffer(10)
         met_config = Helper.default_config()
-        helper_test_post_recoverable_exception(met_config, met_buffer, exception_to_raise,
-                                               error_code, 5)
+        helper_test_post_recoverable_exception(
+            met_config, met_buffer, exception_to_raise, error_code, 5
+        )
         for i in range(10):
-            assert_utf8_equal(met_config.conf, requests.mock_server.data[i], 'batch_%s' % i)
+            assert_utf8_equal(
+                met_config.conf, requests.mock_server.data[i], "batch_%s" % i
+            )
 
 
 def test_post_recoverable_requests_exception():
     request_exception = requests.exceptions.RequestException()
-    exception_cases = [requests.exceptions.ConnectionError(request_exception),
-                       requests.exceptions.Timeout(request_exception),
-                       requests.exceptions.TooManyRedirects(request_exception),
-                       requests.exceptions.StreamConsumedError(request_exception),
-                       requests.exceptions.RetryError(request_exception),
-                       requests.exceptions.ChunkedEncodingError(request_exception),
-                       requests.exceptions.ContentDecodingError(request_exception),
-                       requests.exceptions.URLRequired(request_exception),
-                       requests.exceptions.MissingSchema(request_exception),
-                       requests.exceptions.InvalidSchema(request_exception),
-                       requests.exceptions.InvalidURL(request_exception),
-                       Exception('unknown_exception')]
+    exception_cases = [
+        requests.exceptions.ConnectionError(request_exception),
+        requests.exceptions.Timeout(request_exception),
+        requests.exceptions.TooManyRedirects(request_exception),
+        requests.exceptions.StreamConsumedError(request_exception),
+        requests.exceptions.RetryError(request_exception),
+        requests.exceptions.ChunkedEncodingError(request_exception),
+        requests.exceptions.ContentDecodingError(request_exception),
+        requests.exceptions.URLRequired(request_exception),
+        requests.exceptions.MissingSchema(request_exception),
+        requests.exceptions.InvalidSchema(request_exception),
+        requests.exceptions.InvalidURL(request_exception),
+        Exception("unknown_exception"),
+    ]
 
     for exception_case in exception_cases:
         reset_test_env()
         met_buffer = Helper.get_buffer(10)
         met_config = Helper.default_config()
-        helper_test_post_recoverable_exception(met_config, met_buffer, exception_case,
-                                               "unknown_status_code", 5)
+        helper_test_post_recoverable_exception(
+            met_config, met_buffer, exception_case, "unknown_status_code", 5
+        )
         for i in range(10):
-            assert_utf8_equal(met_config.conf, requests.mock_server.data[i], 'batch_%s' % i)
+            assert_utf8_equal(
+                met_config.conf, requests.mock_server.data[i], "batch_%s" % i
+            )
 
 
 def test_post_fail_after_retries_with_buffer_full():
     met_buffer = Helper.get_buffer(10)
     met_config = Helper.default_config()
-    met_buffer.put_pending_batch(['batch_first'])
-    exception_to_raise = requests.exceptions.HTTPError(requests.exceptions.RequestException())
-    helper_test_post_recoverable_exception(met_config, met_buffer, exception_to_raise, 429, 10)
+    met_buffer.put_pending_batch(["batch_first"])
+    exception_to_raise = requests.exceptions.HTTPError(
+        requests.exceptions.RequestException()
+    )
+    helper_test_post_recoverable_exception(
+        met_config, met_buffer, exception_to_raise, 429, 10
+    )
     for i in range(10):
-        assert_utf8_equal(met_config.conf, requests.mock_server.data[i], 'batch_%s' % i)
+        assert_utf8_equal(met_config.conf, requests.mock_server.data[i], "batch_%s" % i)
 
 
 def test_post_fail_after_retries_with_buffer_not_full():
     met_buffer = Helper.get_buffer(20)
     met_config = Helper.default_config()
-    met_buffer.put_pending_batch(['batch_first'])
-    exception_to_raise = requests.exceptions.HTTPError(requests.exceptions.RequestException())
-    helper_test_post_recoverable_exception(met_config, met_buffer, exception_to_raise, 429, 10)
+    met_buffer.put_pending_batch(["batch_first"])
+    exception_to_raise = requests.exceptions.HTTPError(
+        requests.exceptions.RequestException()
+    )
+    helper_test_post_recoverable_exception(
+        met_config, met_buffer, exception_to_raise, 429, 10
+    )
 
-    assert_utf8_equal(met_config.conf, requests.mock_server.data[0], 'batch_first')
+    assert_utf8_equal(met_config.conf, requests.mock_server.data[0], "batch_first")
     for i in range(1, 10):
-        assert_utf8_equal(met_config.conf, requests.mock_server.data[i], 'batch_%s' % (i - 1))
+        assert_utf8_equal(
+            met_config.conf, requests.mock_server.data[i], "batch_%s" % (i - 1)
+        )
 
 
 #
 # Helper functions
 #
+
 
 @pytest.fixture(scope="function", autouse=True)
 def reset_response_decider_and_fake_server():
@@ -221,24 +245,27 @@ def reset_test_env():
     requests.mock_response.reset()
 
 
-def helper_test_post_recoverable_exception(met_config, met_buffer, exception, error_code,
-                                           stop_raise_exception_after):
+def helper_test_post_recoverable_exception(
+    met_config, met_buffer, exception, error_code, stop_raise_exception_after
+):
 
     configs = {
-        'retry_initial_delay': '0',
-        'retry_max_attempts': '5',
-        'retry_max_delay': '5',
-        'retry_backoff': '1',
-        'retry_jitter_min': '0',
-        'retry_jitter_max': '0'
+        "retry_initial_delay": "0",
+        "retry_max_attempts": "5",
+        "retry_max_delay": "5",
+        "retry_backoff": "1",
+        "retry_jitter_min": "0",
+        "retry_jitter_max": "0",
     }
     Helper.parse_configs(met_config, configs)
 
-    requests.post_response_decider.set(True, False, exception, stop_raise_exception_after, 0)
+    requests.post_response_decider.set(
+        True, False, exception, stop_raise_exception_after, 0
+    )
     requests.mock_response.set(error_code)
 
     for i in range(10):
-        met_buffer.put_pending_batch(['batch_%s' % i])
+        met_buffer.put_pending_batch(["batch_%s" % i])
 
     met_sender = Helper.get_sender(met_config.conf, met_buffer)
 
@@ -248,7 +275,7 @@ def helper_test_post_recoverable_exception(met_config, met_buffer, exception, er
     assert requests.mock_server.headers == {
         HeaderKeys.content_type: met_config.conf[ConfigOptions.content_type],
         HeaderKeys.content_encoding: met_config.conf[ConfigOptions.content_encoding],
-        HeaderKeys.x_sumo_client: 'collectd-plugin'
+        HeaderKeys.x_sumo_client: "collectd-plugin",
     }
 
     met_sender.cancel_timer()
@@ -263,7 +290,7 @@ def helper_test_post_unrecoverable_exception(exception, error_code):
         requests.post_response_decider.set(False, True, exception, 5, 0)
 
         for i in range(10):
-            met_buffer.put_pending_batch(['batch_%s' % i])
+            met_buffer.put_pending_batch(["batch_%s" % i])
 
         Helper.get_sender(helper.conf, met_buffer)
 
@@ -272,18 +299,20 @@ def helper_test_post_unrecoverable_exception(exception, error_code):
 
 def sleep_helper(expected_data_size, sleep_interval, max_tries):
     current_retry = 0
-    while len(requests.mock_server.data) != expected_data_size \
-            and current_retry < max_tries:
+    while (
+        len(requests.mock_server.data) != expected_data_size
+        and current_retry < max_tries
+    ):
         time.sleep(sleep_interval)
         current_retry += 1
 
 
 def assert_utf8_equal(config, compressed, original):
     content_encoding = config[ConfigOptions.content_encoding]
-    original_str = original.encode('utf-8')
-    if content_encoding == 'deflate':
+    original_str = original.encode("utf-8")
+    if content_encoding == "deflate":
         assert zlib.decompress(compressed) == original_str
-    elif content_encoding == 'gzip':
-        assert zlib.decompress(compressed, 16+zlib.MAX_WBITS) == original_str
+    elif content_encoding == "gzip":
+        assert zlib.decompress(compressed, 16 + zlib.MAX_WBITS) == original_str
     else:
         assert compressed == original_str

--- a/test/test_metrics_writer.py
+++ b/test/test_metrics_writer.py
@@ -3,10 +3,10 @@
 import time
 
 import pytest
-
 from collectd import Helper
 from collectd.collectd_config import CollectdConfig
 from collectd.values import Values
+
 from sumologic_collectd_metrics.metrics_config import ConfigOptions
 
 
@@ -45,10 +45,12 @@ def test_write_callback_host_with_equal_char():
     metrics_writer.parse_config(config)
     metrics_writer.init_callback()
     data = Values(host="[invalid=host]")
-    expected_value = ['host=[invalid:host]' \
-    ' plugin=test_plugin plugin_instance=test_plugin_instance' \
-    ' type=test_type type_instance=test_type_instance ds_name=test_ds_name ds_type=test_ds_type' \
-    ' metric=test_type.test_type_instance  test_meta_key=test_meta_val 3.140000 1501775008']
+    expected_value = [
+        "host=[invalid:host]"
+        " plugin=test_plugin plugin_instance=test_plugin_instance"
+        " type=test_type type_instance=test_type_instance ds_name=test_ds_name ds_type=test_ds_type"
+        " metric=test_type.test_type_instance  test_meta_key=test_meta_val 3.140000 1501775008"
+    ]
     metrics_writer.write_callback(data)
 
     assert metrics_writer.met_batcher.queue.qsize() == 1
@@ -83,10 +85,10 @@ def test_write_callback_invalid_metric_name():
         config = CollectdConfig([Helper.url_node()])
         metrics_writer.parse_config(config)
         metrics_writer.init_callback()
-        data = Values(type='test')
+        data = Values(type="test")
         metrics_writer.write_callback(data)
 
-    assert 'Do not know how to handle type test' in str(e)
+    assert "Do not know how to handle type test" in str(e)
 
 
 def test_shutdown_call_back():
@@ -96,7 +98,7 @@ def test_shutdown_call_back():
     metrics_writer.init_callback()
 
     for i in range(10):
-        metrics_writer.met_buffer.put_pending_batch(['batch_%s' % i])
+        metrics_writer.met_buffer.put_pending_batch(["batch_%s" % i])
 
     metrics_writer.shutdown_callback()
 

--- a/test/test_timer.py
+++ b/test/test_timer.py
@@ -19,6 +19,7 @@ def test_cancel_timer_not_start():
 
     timer.cancel_timer()
 
+
 def test_reset_timer_normal():
     timer = Timer(0.1, task)
     timer.start_timer()
@@ -45,4 +46,4 @@ def test_reset_timer_not_start():
 
 
 def task():
-    print('Timer task ... ')
+    print("Timer task ... ")


### PR DESCRIPTION
Make formatting and import ordering consistent by using black and isort. I had to split the requirements file, as black doesn't actually run on Python 2, though it does format Python 2 files. This meant that the lint and test jobs in GHA had to run with different dependencies installed.