### PR TITLE
ci: fix publishing with Markdown README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     version="4.1.0",
     description="A collectd output plugin to send Carbon 2.0-formatted metrics to Sumo Logic.",
     long_description=readme(),
+    long_description_content_type="text/markdown",
     url="https://github.com/SumoLogic/sumologic-collectd-plugin",
     author="Sumo Logic",
     author_email="support@sumologic.com",


### PR DESCRIPTION
Without it, the following error occurs:

> The description failed to render in the default format of reStructuredText. See https://test.pypi.org/help/#description-content-type for more information.
