### PR TITLE
fix: turn statsd tags into dimensions in Sumo

### DIFF
--- a/sumologic_collectd_metrics/metrics_converter.py
+++ b/sumologic_collectd_metrics/metrics_converter.py
@@ -98,7 +98,7 @@ def _gen_metric(dimension_tags, meta_tags, value, timestamp):
 
 
 # Generate dimension tags
-def _gen_dimension_tags(data, ds_name, ds_type):
+def _gen_dimension_tags(data, ds_name, ds_type, extra_dimensions=None):
 
     tags = [
         gen_tag(key, getattr(data, key))
@@ -113,6 +113,9 @@ def _gen_dimension_tags(data, ds_name, ds_type):
         gen_tag(IntrinsicKeys.ds_name, ds_name),
         gen_tag(IntrinsicKeys.ds_type, ds_type),
     ]
+
+    if extra_dimensions:
+        tags += [gen_tag(key, value) for key, value in extra_dimensions.items()]
 
     dimension_tags = _remove_empty_tags(tags)
 
@@ -134,7 +137,7 @@ def _gen_metric_dimension(data, sep):
     ]
 
 
-def convert_to_metrics(data, data_set, sep):
+def convert_to_metrics(data, data_set, sep, extra_dimensions=None):
     """
     Convert data into metrics
     """
@@ -149,7 +152,10 @@ def convert_to_metrics(data, data_set, sep):
         ds_name = data_type[0]
         ds_type = data_type[1]
 
-        dimension_tags = _gen_dimension_tags(data, ds_name, ds_type) + metric_dimension
+        dimension_tags = (
+            _gen_dimension_tags(data, ds_name, ds_type, extra_dimensions)
+            + metric_dimension
+        )
         metric = _gen_metric(dimension_tags, meta_tags, value, data.time)
 
         metrics.append(metric)

--- a/test/test_metrics_writer.py
+++ b/test/test_metrics_writer.py
@@ -11,7 +11,7 @@ except ImportError:  # python 2
 import pytest
 from collectd import Helper
 from collectd.collectd_config import CollectdConfig
-from collectd.values import Values
+from collectd.values import Constants, Values
 
 from sumologic_collectd_metrics.metrics_config import ConfigOptions
 from sumologic_collectd_metrics.metrics_writer import PLUGIN_NAME
@@ -110,7 +110,11 @@ def test_write_callback_signalfx_statsd_tags(initialized_metrics_writer):
     metrics_writer.write_callback(data)
     assert metrics_writer.met_batcher.queue.qsize() == 1
     metric_str = metrics_writer.met_batcher.queue.get()
-    assert " key=value " in metric_str
+
+    # the below checks try to determine if the statsd tag shows up in the right place in the
+    # output Carbon2 metric
+    # in particular, the tag needs to be a dimension, not metadata
+    assert "ds_type=%s key=value" % Constants.ds_types[0] in metric_str
     assert "type_instance=metric.test" in metric_str
 
 


### PR DESCRIPTION
StatsD tags would be treated as metadata in Sumo, when we'd like them to be dimensions instead. This is technically a breaking change, but as it makes a very recent feature work as-intended, I'm going to treat it like a bug fix.